### PR TITLE
fix: some issues with old api and forced subs

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -151,12 +151,6 @@ async function fetchAllSubtitles(imdbId, type, season = null, episode = null, vi
 
   if (type === 'series' && season && episode) {
     apiUrl += `:${season}:${episode}`;
-  } else {
-    // Use video hash for better matching if possible, else, 
-    // do nothing as that will cause the API to return old unusable subtitles (from subs-v1.strem.io)
-    if (videoParams.videoHash) {
-      apiUrl += `:${videoParams.videoHash}`;
-    }
   }
 
   // Add query params for better matching
@@ -170,6 +164,8 @@ async function fetchAllSubtitles(imdbId, type, season = null, episode = null, vi
   }
 
   apiUrl += '.json';
+
+  console.log('Fetching subtitles from:', apiUrl);
 
   try {
     const response = await fetchWithRetry(apiUrl, { timeout: 15000 });


### PR DESCRIPTION
The issues fixed are as follows:
- The `:<hash>` API endpoint appears to now return URLs to `subs-v1.strem.io`, which appears to be deprecated as connecting to any of them result in an error: `{"error":"Blocked"}`. [Here's an example](https://opensubtitles-v3.strem.io/subtitles/movie/tt5311514:0.json)
- Attempt to filter and ignore Forced Subs (as those usually only exist for the purpose of showing signs/on-screen text. Not useful for our purpose.