### PR TITLE
fix: subtitle display

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -99,7 +99,7 @@ const manifest = {
   description: 'Watch movies and series with dual subtitles - see two languages simultaneously for better language learning!',
   resources: ['subtitles'],
   types: ['movie', 'series'],
-  idPrefixes: ['tt'],
+  idPrefixes: ['tt', 'kitsu'],
   catalogs: [],
   logo: '/logo.png',
   behaviorHints: {
@@ -130,6 +130,11 @@ const manifest = {
   ]
 };
 
+const MovieType = {
+  IMDB: 'imdb',
+  KITSU: 'kitsu'
+}
+
 const builder = new addonBuilder(manifest);
 
 async function fetchWithRetry(url, options = {}, retries = 2, backoffMs = 500) {
@@ -148,8 +153,13 @@ async function fetchWithRetry(url, options = {}, retries = 2, backoffMs = 500) {
 /**
  * Fetch all subtitles from OpenSubtitles API.
  */
-async function fetchAllSubtitles(imdbId, type, season = null, episode = null, videoParams = {}) {
-  let apiUrl = `https://opensubtitles-v3.strem.io/subtitles/${type}/tt${imdbId}`;
+async function fetchAllSubtitles(id, movieType, type, season = null, episode = null, videoParams = {}) {
+  let apiUrl = '';
+  if (movieType === MovieType.IMDB) {
+    apiUrl = `https://opensubtitles-v3.strem.io/subtitles/${type}/tt${id}`;
+  } else if (movieType === MovieType.KITSU) {
+    apiUrl = `https://anime-kitsu.strem.fun/subtitles/movie/${id}`;
+  }
 
   if (type === 'series' && season && episode) {
     apiUrl += `:${season}:${episode}`;
@@ -536,25 +546,35 @@ async function subtitlesHandler({ type, id, extra, config }) {
     return { subtitles: [] };
   }
 
-  // Parse IMDB ID
-  let imdbId = extra?.imdbId || id;
-  let season = extra?.season;
-  let episode = extra?.episode;
+  let movieType = MovieType.IMDB;
 
-  if (imdbId.includes(':')) {
-    const parts = imdbId.split(':');
-    imdbId = parts[0];
-    if (parts.length >= 3) {
-      season = season || parts[1];
-      episode = episode || parts[2];
-    }
+  if (id.startsWith('kitsu')) {
+    movieType = MovieType.KITSU;
   }
 
-  imdbId = imdbId.replace('tt', '');
+  let season;
+  let episode;
 
-  if (!imdbId) {
-    debugServer.warn('No valid IMDB ID');
-    return { subtitles: [] };
+  if (movieType === MovieType.IMDB) {
+    // Parse IMDB ID
+    id = extra?.imdbId || id;
+    season = extra?.season;
+    episode = extra?.episode;
+
+    if (id.includes(':')) {
+      const parts = id.split(':');
+      id = parts[0];
+      if (parts.length >= 3) {
+        season = season || parts[1];
+        episode = episode || parts[2];
+      }
+    }
+    id = id.replace('tt', '');
+
+    if (!id) {
+      debugServer.warn('No valid IMDB ID');
+      return { subtitles: [] };
+    }
   }
 
   try {
@@ -567,7 +587,7 @@ async function subtitlesHandler({ type, id, extra, config }) {
 
     // Fetch all subtitles
     debugServer.log('Fetching subtitles from OpenSubtitles...');
-    const allSubtitles = await fetchAllSubtitles(imdbId, type, season, episode, videoParams);
+    const allSubtitles = await fetchAllSubtitles(id, movieType, type, season, episode, videoParams);
 
     if (!allSubtitles) {
       debugServer.warn('No subtitles found');
@@ -640,13 +660,13 @@ async function subtitlesHandler({ type, id, extra, config }) {
       if (!mergedSrt) continue;
 
       // Store in cache (for local/backup)
-      const cacheKey = `${imdbId}_${season || ''}_${episode || ''}_${mainLang}_${transLang}_v${version}`;
+      const cacheKey = `${id}_${season || ''}_${episode || ''}_${mainLang}_${transLang}_v${version}`;
       storeSubtitle(cacheKey, mergedSrt);
 
       // Use dynamic URL that regenerates subtitle on each request (for serverless)
       const dynamicParams = [
         type,
-        imdbId,
+        id,
         season || '0',
         episode || '0',
         mainLang,
@@ -683,15 +703,21 @@ builder.defineSubtitlesHandler(subtitlesHandler);
  * Generate merged subtitle dynamically (for serverless environments)
  * Called directly by URL - no cache dependency
  */
-async function generateDynamicSubtitle(type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId) {
-  debugServer.log('Dynamic subtitle generation:', { type, imdbId, mainLang, transLang });
+async function generateDynamicSubtitle(type, id, season, episode, mainLang, transLang, mainSubId, transSubId) {
+  debugServer.log('Dynamic subtitle generation:', { type, id, mainLang, transLang });
+
+  let movieType = MovieType.IMDB;
+  if (id.startsWith('kitsu')) {
+    movieType = MovieType.KITSU;
+  }
 
   try {
     // Fetch all subtitles
     const allSubtitles = await fetchAllSubtitles(
-      imdbId, 
-      type, 
-      season !== '0' ? season : null, 
+      id,
+      movieType,
+      type,
+      season !== '0' ? season : null,
       episode !== '0' ? episode : null
     );
 

--- a/addon.js
+++ b/addon.js
@@ -382,11 +382,15 @@ function msToSrtTime(ms) {
 /**
  * Join multi-line subtitle text into a single line.
  * For CJK languages, joins without spaces to avoid breaking character flow.
+ * If stripSSATags is true, removes SSA tags from the text.
  */
-function joinSubtitleLines(text, langCode) {
+function joinSubtitleLines(text, langCode, stripSSATags = false) {
   if (!text) return '';
   const cjk = isCjkLanguage(langCode);
-  return text.replace(/\r?\n|\r/g, cjk ? '' : ' ').trim();
+  if (stripSSATags) text = text.replace(/\{[^}]*\}/g, '');
+  return text
+    .replace(/\r?\n|\r/g, cjk ? '' : ' ')
+    .trim();
 }
 
 /**
@@ -455,7 +459,8 @@ function mergeSubtitles(mainSubs, transSubs, options = {}) {
       const transSub = transSubs[bestMatchIndex];
       const cleanTransText = joinSubtitleLines(
         sanitize(transSub.text, { allowedTags: [], allowedAttributes: {} }),
-        transLang
+        transLang,
+        true
       );
 
       if (cleanTransText) {

--- a/server.js
+++ b/server.js
@@ -10,12 +10,12 @@ const express = require('express');
 const compression = require('compression');
 const { getRouter } = require('stremio-addon-sdk');
 const { debugServer, sanitizeForLogging } = require('./lib/debug');
-const { 
-  trackPageView, 
-  trackInstall, 
-  trackSubtitleRequest, 
+const {
+  trackPageView,
+  trackInstall,
+  trackSubtitleRequest,
   trackSubtitleServed,
-  getAnalyticsSummary 
+  getAnalyticsSummary
 } = require('./lib/analytics');
 const { generateStatsHTML, generatePrivacyHTML, generateErrorHTML } = require('./lib/templates');
 const { builder, manifest, getSubtitle, subtitlesHandler, generateDynamicSubtitle } = require('./addon');
@@ -99,7 +99,7 @@ app.use((req, res, next) => {
   if (req.path.startsWith('/logo') || req.path === '/health') {
     return next();
   }
-  
+
   const ip = getClientIP(req);
   const now = Date.now();
 
@@ -135,7 +135,7 @@ app.post('/api/track', (req, res) => {
   try {
     const { event, page, mainLang, transLang, contentType } = req.body;
     const ip = getClientIP(req);
-    
+
     switch (event) {
       case 'pageView':
         trackPageView(ip, page);
@@ -147,7 +147,7 @@ app.post('/api/track', (req, res) => {
         trackSubtitleRequest(mainLang, transLang, contentType);
         break;
     }
-    
+
     res.json({ success: true });
   } catch (error) {
     res.json({ success: false });
@@ -156,8 +156,8 @@ app.post('/api/track', (req, res) => {
 
 // Health check endpoint
 app.get('/health', (req, res) => {
-  res.json({ 
-    status: 'ok', 
+  res.json({
+    status: 'ok',
     version: manifest.version,
     uptime: process.uptime()
   });
@@ -183,14 +183,14 @@ app.get('/configure', (req, res) => {
 // Analytics dashboard (protected with secret key)
 app.get('/stats', (req, res) => {
   const analyticsSecret = process.env.ANALYTICS_SECRET;
-  
+
   // If secret is set, require it in query parameter
   if (analyticsSecret && req.query.key !== analyticsSecret) {
     const baseUrl = getExternalUrl(req);
     const manifestWithLogo = getManifestWithLogo(req);
     return res.status(401).send(generateErrorHTML(401, 'Unauthorized', baseUrl, manifestWithLogo));
   }
-  
+
   const baseUrl = getExternalUrl(req);
   const manifestWithLogo = getManifestWithLogo(req);
   const stats = getAnalyticsSummary();
@@ -262,17 +262,17 @@ app.get('/sitemap.xml', (req, res) => {
 app.get('/subtitles/:filename', (req, res) => {
   const filename = req.params.filename;
   const cacheKey = filename.replace('.srt', '');
-  
+
   const content = getSubtitle(cacheKey);
-  
+
   if (!content) {
     debugServer.warn(`Subtitle not found in cache: ${cacheKey}`);
     return res.status(404).send('Subtitle not found or expired');
   }
-  
+
   trackSubtitleServed();
-  
-  res.setHeader('Content-Type', 'text/srt; charset=utf-8');
+
+  res.setHeader('Content-Type', 'application/x-subrip; charset=utf-8');
   res.setHeader('Cache-Control', 'public, max-age=21600');
   res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
   res.send(content);
@@ -282,22 +282,22 @@ app.get('/subtitles/:filename', (req, res) => {
 // URL format: /subs/:type/:imdbId/:season/:episode/:mainLang/:transLang/:mainSubId/:transSubId.srt
 app.get('/subs/:type/:imdbId/:season/:episode/:mainLang/:transLang/:mainSubId/:transSubId.srt', async (req, res) => {
   const { type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId } = req.params;
-  
+
   debugServer.log(`Dynamic subtitle request: ${type}/${imdbId} ${mainLang}+${transLang}`);
-  
+
   try {
     const content = await generateDynamicSubtitle(
       type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId
     );
-    
+
     if (!content) {
       debugServer.warn('Could not generate dynamic subtitle');
       return res.status(404).send('Subtitle generation failed');
     }
-    
+
     trackSubtitleServed();
-    
-    res.setHeader('Content-Type', 'text/srt; charset=utf-8');
+
+    res.setHeader('Content-Type', 'application/x-subrip; charset=utf-8');
     res.setHeader('Cache-Control', 'public, max-age=3600');
     res.setHeader('Content-Disposition', `inline; filename="dual_${mainLang}_${transLang}.srt"`);
     res.send(content);
@@ -317,7 +317,7 @@ app.get('/:config/manifest.json', (req, res) => {
   try {
     const configParam = decodeURIComponent(req.params.config);
     const [mainLang, transLang] = configParam.split('|');
-    
+
     if (!mainLang || !transLang) {
       return res.status(400).json({ error: 'Invalid configuration' });
     }
@@ -350,7 +350,7 @@ app.get('/:config/subtitles/:type/:id/:extra?.json', async (req, res) => {
   try {
     const configParam = decodeURIComponent(req.params.config);
     const [mainLang, transLang] = configParam.split('|');
-    
+
     if (!mainLang || !transLang) {
       return res.status(400).json({ subtitles: [] });
     }
@@ -367,7 +367,7 @@ app.get('/:config/subtitles/:type/:id/:extra?.json', async (req, res) => {
     debugServer.log(`Subtitle request: ${type}/${id}, langs: ${parseLangCode(mainLang)}+${parseLangCode(transLang)}`);
 
     const result = await subtitlesHandler({ type, id, extra, config });
-    
+
     // Replace placeholder URL with actual server URL
     const baseUrl = getExternalUrl(req);
     if (result.subtitles) {
@@ -387,10 +387,10 @@ app.get('/:config/subtitles/:type/:id/:extra?.json', async (req, res) => {
 // Parse extra parameters from URL
 function parseExtra(extraStr) {
   const extra = {};
-  
+
   // Handle the format: videoHash.videoSize.filename or just extra params
   const parts = extraStr.split('.');
-  
+
   // Try to parse as key=value pairs
   for (const part of parts) {
     if (part.includes('=')) {
@@ -398,7 +398,7 @@ function parseExtra(extraStr) {
       extra[key] = value;
     }
   }
-  
+
   // Also handle query-style params
   if (extraStr.includes('&')) {
     const params = extraStr.split('&');
@@ -409,7 +409,7 @@ function parseExtra(extraStr) {
       }
     }
   }
-  
+
   return extra;
 }
 


### PR DESCRIPTION
Fixed:
- On Android TV, the subtitles need to have a MIME type of `application/x-subrip`. This is also the case for upstream addons.
- Strip SSA formatting tags from the secondary language's subtitles. The reason being that these do not have an effect (as they are on the second row in the middle of a subtitle line), and this cause them to show up in the output when loaded by stremio:

Before: (推しの子 - ep 9 - 13:00 for reference):
<img width="1912" height="1241" alt="image" src="https://github.com/user-attachments/assets/ce4099fb-83d0-4af9-85d6-7eb751382711" />

After: 
<img width="1912" height="1241" alt="image" src="https://github.com/user-attachments/assets/43d85cd4-f61f-422a-b198-814b980df718" />

