### PR TITLE
Smart source pairing + multi-stage subtitle sync engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Android TV subtitle listing compatibility by using a standard single `lang` code for dual subtitles and clearer dual naming format (`#8`)
 - Clearer visual distinction between primary and secondary lines in merged SRT (`<b>`, muted color, and a `›` marker) for clients that support basic SRT HTML (`#9`)
+- Dual-subtitle desync between two language tracks taken from different releases. Replaced the single-pass nearest-start-time matcher with a multi-stage alignment engine (`lib/syncEngine.js`):
+  - **Stage 1 — global offset:** cross-correlation of cue presence signals detects a uniform shift between the tracks (the most common failure mode, e.g. The Sopranos S01E03 ENG+TUR where the entire translation was off by ~2.5s).
+  - **Stage 2 — linear drift:** least-squares affine fit on anchor pairs corrects framerate-mismatch drift (e.g. 23.976 vs 25 fps).
+  - **Stage 3 — bipartite assignment:** overlap-fraction (Jaccard) scoring with used-set tracking, so a single translation cue can no longer be glued to two different primary cues.
+  - **Stage 4 — 1:N consolidation:** a primary cue may absorb multiple short translation cues that all overlap it, fixing cue-boundary mismatches.
 
 ## [1.1.0] - 2026-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+
 - Android TV subtitle listing compatibility by using a standard single `lang` code for dual subtitles and clearer dual naming format (`#8`)
 - Clearer visual distinction between primary and secondary lines in merged SRT (`<b>`, muted color, and a `›` marker) for clients that support basic SRT HTML (`#9`)
 - Dual-subtitle desync between two language tracks taken from different releases. Replaced the single-pass nearest-start-time matcher with a multi-stage alignment engine (`lib/syncEngine.js`):
   - **Stage 1 — global offset:** cross-correlation of cue presence signals detects a uniform shift between the tracks (the most common failure mode, e.g. The Sopranos S01E03 ENG+TUR where the entire translation was off by ~2.5s).
   - **Stage 2 — linear drift:** least-squares affine fit on anchor pairs corrects framerate-mismatch drift (e.g. 23.976 vs 25 fps).
-  - **Stage 3 — bipartite assignment:** overlap-fraction (Jaccard) scoring with used-set tracking, so a single translation cue can no longer be glued to two different primary cues.
-  - **Stage 4 — 1:N consolidation:** a primary cue may absorb multiple short translation cues that all overlap it, fixing cue-boundary mismatches.
+  - **Stage 3 — sliding-window local offsets:** per-window cross-correlation produces piecewise-linear anchor offsets so non-linear drift (cuts/edits, ad break differences between releases) gets corrected segment-by-segment instead of with a single global slope.
+  - **Stage 4 — bipartite assignment:** overlap-fraction (Jaccard) scoring with used-set tracking, so a single translation cue can no longer be glued to two different primary cues.
+  - **Stage 5 — 1:N consolidation:** a primary cue may absorb multiple short translation cues that all overlap it, fixing cue-boundary mismatches.
+- Dual-subtitle source pairing. The OpenSubtitles v3 stream API exposes a `g` field (release/source grouping id) that the previous picker ignored, so it would routinely pair the most-popular ENG sub with the most-popular TUR sub even when they were timed against completely different releases. New `lib/sourceSelection.js` builds an ordered list of candidate (main, trans) pairs that interleaves same-`g` pairs (same source upload, almost always sync cleanly) with the legacy zipped-popularity pair (insurance for the cases where `g` is unreliable). `subtitlesHandler` and `generateDynamicSubtitle` now run a quality gate over up to three pairs and pick the one with the highest measured match rate. Measured improvements on real titles:
+  - Sopranos S01E03 (eng+tur): 76.9% → **99.5%** (+22.7pp)
+  - Sopranos S01E01 (eng+tur): 69.1% → **91.0%** (+21.9pp)
+  - Inception (eng+tur): 67.9% → **90.3%** (+22.4pp)
+  - Inception (eng+spa): 69.7% → **85.4%** (+15.8pp)
+  - Breaking Bad S01E01 (eng+spa): 75.7% → **82.4%** (+6.7pp)
+  - Sopranos S02E05 / Shawshank / Game of Thrones S01E01: tied (no regressions)
+  - Mean across 8 titles: **+11.2pp**, 5 wins, 3 ties, 0 losses
 
 ## [1.1.0] - 2026-02-04
 
 ### Added
+
 - **Analytics Dashboard**: Real-time usage statistics at `/stats`
   - Page views, installs, and subtitle requests tracking
   - Hourly activity chart
@@ -37,11 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions CI/CD**: Automated testing and deployment checks
 
 ### Changed
+
 - Improved landing page design with animations
 - Enhanced subtitle preview with multiple language support
 - Better mobile responsiveness
 
 ### Technical
+
 - Added `compression` middleware for gzip
 - Created `lib/analytics.js` for usage tracking
 - Created `lib/templates.js` for HTML page generation
@@ -50,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2026-02-03
 
 ### Added
+
 - Initial release
 - Dual subtitle merging for movies and series
 - Support for 70+ languages via OpenSubtitles
@@ -62,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debug logging system
 
 ### Features
+
 - Primary language displayed on top
 - Secondary language (native) displayed below in italics
 - Automatic browser language detection
@@ -73,13 +88,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Roadmap
 
 ### Planned for v1.2.0
-- [ ] Subtitle style customization (colors, sizes)
-- [ ] Offline caching for mobile
-- [ ] Subtitle delay adjustment
-- [ ] Export merged subtitles
+
+- Subtitle style customization (colors, sizes)
+- Offline caching for mobile
+- Subtitle delay adjustment
+- Export merged subtitles
 
 ### Planned for v2.0.0
-- [ ] User accounts and preferences sync
-- [ ] Vocabulary highlighting
-- [ ] Flashcard generation from subtitles
-- [ ] Community translations
+
+- User accounts and preferences sync
+- Vocabulary highlighting
+- Flashcard generation from subtitles
+- Community translations
+

--- a/addon.js
+++ b/addon.js
@@ -77,13 +77,14 @@ function formatSrtSimple(subtitles) {
 }
 
 const { decodeSubtitleBuffer, getLanguageAliases, isCjkLanguage } = require('./encoding');
-const { 
-  languageMap, 
-  getLanguageOptions, 
-  extractBrowserLanguage, 
+const {
+  languageMap,
+  getLanguageOptions,
+  extractBrowserLanguage,
   parseLangCode,
-  getLanguageName 
+  getLanguageName
 } = require('./languages');
+const { alignAndMatch } = require('./lib/syncEngine');
 
 // Configuration
 const ADDON_NAME = process.env.ADDON_NAME || 'Dual Subtitles';
@@ -393,77 +394,94 @@ function htmlEncodeSrt(text) {
 const DUAL_SUB_TRANS_COLOR = '#94a3b8';
 
 /**
- * Merge two subtitle arrays based on time overlap.
- * @param {Array} mainSubs - Primary language subtitles
- * @param {Array} transSubs - Translation language subtitles
- * @param {Object} options - Merge options
- * @param {number} options.mergeThresholdMs - Max ms gap to consider a match (default 500)
- * @param {string|null} options.mainLang - Primary language code for CJK-aware joining
- * @param {string|null} options.transLang - Translation language code for CJK-aware joining
+ * Merge two subtitle arrays into one, aligning the secondary track to the
+ * primary track's timebase before matching.
+ *
+ * The actual alignment work (global offset detection via cross-correlation,
+ * affine drift correction, and overlap-based bipartite assignment) is in
+ * lib/syncEngine.js. This function is a thin wrapper that converts SRT
+ * timestamp strings to milliseconds, runs the engine, and renders the
+ * dual-line SRT text.
+ *
+ * @param {Array} mainSubs - Primary language subtitles (SRT-time strings)
+ * @param {Array} transSubs - Translation language subtitles (SRT-time strings)
+ * @param {Object|number} options - Merge options (number = legacy threshold)
+ * @param {string|null} [options.mainLang]  - For CJK-aware line joining
+ * @param {string|null} [options.transLang] - For CJK-aware line joining
+ * @param {number}      [options.matchThresholdMs=1500]
+ * @param {boolean}     [options.allowMultiTrans=true]
+ *        If true, several short trans cues may be concatenated into one
+ *        primary cue (handles cue-boundary mismatches).
+ * @param {boolean}     [options.enableOffset=true]
+ * @param {boolean}     [options.enableDrift=true]
  */
 function mergeSubtitles(mainSubs, transSubs, options = {}) {
+  const opts = typeof options === 'number'
+    ? { matchThresholdMs: Math.max(options, 1500) }
+    : options;
+
   const {
-    mergeThresholdMs = 500,
     mainLang = null,
-    transLang = null
-  } = typeof options === 'number' ? { mergeThresholdMs: options } : options;
+    transLang = null,
+    matchThresholdMs = 1500,
+    allowMultiTrans = true,
+    enableOffset = true,
+    enableDrift = true
+  } = opts;
 
+  const mainTimed = [];
+  for (const s of mainSubs || []) {
+    if (!s || !s.startTime || !s.endTime) continue;
+    const startMs = parseTimeToMs(s.startTime);
+    const endMs = parseTimeToMs(s.endTime);
+    if (endMs <= startMs) continue;
+    mainTimed.push({ ...s, startMs, endMs });
+  }
+
+  const transTimed = [];
+  for (const s of transSubs || []) {
+    if (!s || !s.startTime || !s.endTime) continue;
+    const startMs = parseTimeToMs(s.startTime);
+    const endMs = parseTimeToMs(s.endTime);
+    if (endMs <= startMs) continue;
+    transTimed.push({ ...s, startMs, endMs });
+  }
+
+  const { matches } = alignAndMatch(mainTimed, transTimed, {
+    enableOffset,
+    enableDrift,
+    matchThreshold: matchThresholdMs,
+    allowMultiTrans,
+    log: msg => debugServer.log(sanitizeForLogging(msg))
+  });
+
+  const transJoiner = isCjkLanguage(transLang) ? '' : ' ';
   const mergedSubs = [];
-  let transIndex = 0;
 
-  for (const mainSub of mainSubs) {
-    if (!mainSub || !mainSub.startTime || !mainSub.endTime) continue;
-
-    const mainStartTime = parseTimeToMs(mainSub.startTime);
-    const mainEndTime = parseTimeToMs(mainSub.endTime);
-
-    let bestMatchIndex = -1;
-    let smallestTimeDiff = Infinity;
-
-    for (let i = transIndex; i < transSubs.length; i++) {
-      const transSub = transSubs[i];
-      if (!transSub || !transSub.startTime || !transSub.endTime) continue;
-
-      const transStartTime = parseTimeToMs(transSub.startTime);
-      const transEndTime = parseTimeToMs(transSub.endTime);
-
-      const startsOverlap = transStartTime >= mainStartTime && transStartTime < mainEndTime;
-      const endsOverlap = transEndTime > mainStartTime && transEndTime <= mainEndTime;
-      const isWithin = transStartTime >= mainStartTime && transEndTime <= mainEndTime;
-      const contains = transStartTime < mainStartTime && transEndTime > mainEndTime;
-      const timeDiff = Math.abs(mainStartTime - transStartTime);
-
-      if (startsOverlap || endsOverlap || isWithin || contains || timeDiff < mergeThresholdMs) {
-        if (timeDiff < smallestTimeDiff) {
-          smallestTimeDiff = timeDiff;
-          bestMatchIndex = i;
-        }
-      } else if (transStartTime > mainEndTime + mergeThresholdMs) {
-        break;
-      }
-
-      if (transEndTime < mainStartTime - mergeThresholdMs * 2 && i === transIndex) {
-        transIndex = i + 1;
-      }
-    }
+  for (let mi = 0; mi < mainTimed.length; mi++) {
+    const mainSub = mainTimed[mi];
 
     const cleanMainText = joinSubtitleLines(
       sanitize(mainSub.text, { allowedTags: [], allowedAttributes: {} }),
       mainLang
     );
-
     if (!cleanMainText) continue;
 
     let mergedText;
-
-    if (bestMatchIndex !== -1) {
-      const transSub = transSubs[bestMatchIndex];
-      const cleanTransText = joinSubtitleLines(
-        sanitize(transSub.text, { allowedTags: [], allowedAttributes: {} }),
-        transLang
-      );
-
-      if (cleanTransText) {
+    const transIdxs = matches.get(mi);
+    if (transIdxs && transIdxs.length > 0) {
+      const transParts = [];
+      for (const ti of transIdxs) {
+        const t = transTimed[ti];
+        if (!t) continue;
+        const piece = joinSubtitleLines(
+          sanitize(t.text, { allowedTags: [], allowedAttributes: {} }),
+          transLang
+        );
+        if (piece) transParts.push(piece);
+      }
+      if (transParts.length > 0) {
+        const cleanTransText = transParts.join(transJoiner);
         const encMain = htmlEncodeSrt(cleanMainText);
         const encTrans = htmlEncodeSrt(cleanTransText);
         mergedText =
@@ -478,7 +496,9 @@ function mergeSubtitles(mainSubs, transSubs, options = {}) {
     if (!mergedText) continue;
 
     mergedSubs.push({
-      ...mainSub,
+      id: mainSub.id,
+      startTime: mainSub.startTime,
+      endTime: mainSub.endTime,
       text: mergedText
     });
   }

--- a/addon.js
+++ b/addon.js
@@ -85,6 +85,18 @@ const {
   getLanguageName
 } = require('./languages');
 const { alignAndMatch } = require('./lib/syncEngine');
+const { generateCandidatePairs } = require('./lib/sourceSelection');
+
+// Match rate at or above this is considered "good enough" — we stop
+// trying further candidate pairs. Empirically high-quality matches land
+// 90-99%, decent ones 80-90%, mismatched ones 45-70%. We pick 0.85 so
+// the gate trusts a clearly-high pair (1 attempt) but still spends a
+// second fetch to triangulate when the first is only "okay".
+const QUALITY_GATE_THRESHOLD = 0.85;
+// Hard cap on how many pairs we'll fetch+merge before giving up. Three
+// is enough to cover (best same-group, zipped-popularity, runner-up)
+// while keeping the serverless cold path bounded.
+const MAX_PAIR_ATTEMPTS = 3;
 
 // Configuration
 const ADDON_NAME = process.env.ADDON_NAME || 'Dual Subtitles';
@@ -447,13 +459,14 @@ function mergeSubtitles(mainSubs, transSubs, options = {}) {
     transTimed.push({ ...s, startMs, endMs });
   }
 
-  const { matches } = alignAndMatch(mainTimed, transTimed, {
+  const alignment = alignAndMatch(mainTimed, transTimed, {
     enableOffset,
     enableDrift,
     matchThreshold: matchThresholdMs,
     allowMultiTrans,
     log: msg => debugServer.log(sanitizeForLogging(msg))
   });
+  const { matches } = alignment;
 
   const transJoiner = isCjkLanguage(transLang) ? '' : ' ';
   const mergedSubs = [];
@@ -503,6 +516,23 @@ function mergeSubtitles(mainSubs, transSubs, options = {}) {
     });
   }
 
+  // Backwards compatible: callers that used `mergeSubtitles` as a plain
+  // array still iterate / .length / spread it as before. Quality-gate
+  // callers can read alignment metrics from non-enumerable properties.
+  Object.defineProperty(mergedSubs, 'matchRate', {
+    value: alignment.matchRate || 0,
+    enumerable: false
+  });
+  Object.defineProperty(mergedSubs, 'alignment', {
+    value: {
+      offsetMs: alignment.offsetMs,
+      drift: alignment.drift,
+      localAnchors: alignment.localAnchors,
+      matchedCount: matches.size,
+      mainCount: mainTimed.length
+    },
+    enumerable: false
+  });
   return mergedSubs;
 }
 
@@ -557,6 +587,90 @@ function getSubtitle(key) {
   }
   
   return entry.content;
+}
+
+/**
+ * Try candidate (main, trans) pairs in order. For each pair, fetch both
+ * subtitle files, parse them, and run mergeSubtitles. The first pair whose
+ * match rate clears QUALITY_GATE_THRESHOLD wins; otherwise we return the
+ * best pair we saw, capped at MAX_PAIR_ATTEMPTS.
+ *
+ * Each fetched subtitle is cached in `parsedCache` so retrying with the
+ * same main against a different trans (or vice versa) doesn't re-download.
+ *
+ * @param {Array} candidatePairs    output of generateCandidatePairs
+ * @param {string} mainLang
+ * @param {string} transLang
+ * @returns {Promise<{
+ *   merged: Array, mergedSrt: string, matchRate: number,
+ *   mainSub: object, transSub: object, attempts: number,
+ *   passedGate: boolean
+ * } | null>}
+ */
+async function selectAndMergeBestPair(candidatePairs, mainLang, transLang) {
+  if (!Array.isArray(candidatePairs) || candidatePairs.length === 0) return null;
+
+  const parsedCache = new Map();
+  async function getParsed(sub, lang) {
+    if (parsedCache.has(sub.id)) return parsedCache.get(sub.id);
+    const content = await fetchSubtitleContent(sub.url, lang);
+    const parsed = content ? parseSrt(content) : null;
+    parsedCache.set(sub.id, parsed);
+    return parsed;
+  }
+
+  let best = null;
+  const attempts = Math.min(candidatePairs.length, MAX_PAIR_ATTEMPTS);
+
+  for (let i = 0; i < attempts; i++) {
+    const pair = candidatePairs[i];
+    debugServer.log(
+      `Pair attempt ${i + 1}/${attempts}: main=${pair.main.id} trans=${pair.trans.id} ` +
+      `source=${pair.source} sameGroup=${pair.sameGroup} g=${pair.group}`
+    );
+
+    const [mainParsed, transParsed] = await Promise.all([
+      getParsed(pair.main, mainLang),
+      getParsed(pair.trans, transLang)
+    ]);
+    if (!mainParsed || mainParsed.length === 0) {
+      debugServer.warn(`  main subtitle ${pair.main.id} unparsable, skipping`);
+      continue;
+    }
+    if (!transParsed || transParsed.length === 0) {
+      debugServer.warn(`  trans subtitle ${pair.trans.id} unparsable, skipping`);
+      continue;
+    }
+
+    const merged = mergeSubtitles(mainParsed, transParsed, { mainLang, transLang });
+    const matchRate = merged && merged.matchRate != null ? merged.matchRate : 0;
+    debugServer.log(`  match rate: ${(matchRate * 100).toFixed(1)}%`);
+
+    if (!best || matchRate > best.matchRate) {
+      best = {
+        merged,
+        mergedSrt: merged && merged.length > 0 ? formatSrt(merged) : null,
+        matchRate,
+        mainSub: pair.main,
+        transSub: pair.trans,
+        attempts: i + 1,
+        passedGate: matchRate >= QUALITY_GATE_THRESHOLD
+      };
+    }
+    if (matchRate >= QUALITY_GATE_THRESHOLD) {
+      debugServer.log(`  passed quality gate, stopping`);
+      break;
+    }
+  }
+
+  if (best) {
+    debugServer.log(
+      `Selected pair: main=${best.mainSub.id} trans=${best.transSub.id} ` +
+      `matchRate=${(best.matchRate * 100).toFixed(1)}% attempts=${best.attempts} ` +
+      `passedGate=${best.passedGate}`
+    );
+  }
+  return best;
 }
 
 // Subtitle handler function
@@ -618,94 +732,58 @@ async function subtitlesHandler({ type, id, extra, config }) {
 
     debugServer.log(`Found ${allSubtitles.length} total subtitles`);
 
-    // Filter by languages
-    const mainSubList = filterSubtitlesByLanguage(allSubtitles, mainLang);
-    const transSubList = filterSubtitlesByLanguage(allSubtitles, transLang);
+    // Build the ordered list of (main, trans) candidates. Same-`g`
+    // (same release) pairs come first; this is our biggest single
+    // accuracy win on titles like Sopranos S01E03.
+    const candidatePairs = generateCandidatePairs(allSubtitles, mainLang, transLang);
 
-    if (!mainSubList || mainSubList.length === 0) {
-      debugServer.warn(`No ${mainLang} subtitles found`);
+    if (candidatePairs.length === 0) {
+      debugServer.warn(`No ${mainLang}/${transLang} candidate pairs available`);
       return { subtitles: [] };
     }
 
-    if (!transSubList || transSubList.length === 0) {
-      debugServer.warn(`No ${transLang} subtitles found`);
+    debugServer.log(
+      `Built ${candidatePairs.length} candidate pair(s); ` +
+      `same-group: ${candidatePairs.filter(p => p.sameGroup).length}`
+    );
+
+    // Run the quality gate. selectAndMergeBestPair fetches/parses each
+    // candidate pair, computes match rate, and stops when one clears
+    // the gate. This keeps cold-path latency bounded.
+    const best = await selectAndMergeBestPair(candidatePairs, mainLang, transLang);
+
+    if (!best || !best.merged || best.merged.length === 0 || !best.mergedSrt) {
+      debugServer.warn('No usable merged subtitle from any candidate pair');
       return { subtitles: [] };
     }
 
-    debugServer.log(`Found ${mainSubList.length} ${mainLang} and ${transSubList.length} ${transLang} subtitles`);
+    const cacheKey = `${imdbId}_${season || ''}_${episode || ''}_${mainLang}_${transLang}_v1`;
+    storeSubtitle(cacheKey, best.mergedSrt);
 
-    // Process and create merged subtitles
-    const finalSubtitles = [];
-    const usedTransUrls = new Set();
+    const dynamicParams = [
+      type,
+      imdbId,
+      season || '0',
+      episode || '0',
+      mainLang,
+      transLang,
+      best.mainSub.id,
+      best.transSub.id
+    ].join('/');
 
-    // Find a valid main subtitle first
-    let mainParsed = null;
-    let selectedMainSub = null;
+    const finalSubtitles = [{
+      id: `dual-${best.mainSub.id}-${best.transSub.id}`,
+      url: `{{ADDON_URL}}/subs/${dynamicParams}.srt`,
+      lang: mainLang,
+      SubtitlesName:
+        `Dual (${mainLang.toUpperCase()}+${transLang.toUpperCase()}) - ` +
+        `${getLanguageName(mainLang)} + ${getLanguageName(transLang)}`
+    }];
 
-    for (const mainSubInfo of mainSubList) {
-      const content = await fetchSubtitleContent(mainSubInfo.url, mainSubInfo.lang);
-      if (!content) continue;
-
-      const parsed = parseSrt(content);
-      if (!parsed || parsed.length === 0) continue;
-
-      mainParsed = parsed;
-      selectedMainSub = mainSubInfo;
-      debugServer.log(`Using main subtitle: ${mainSubInfo.id}`);
-      break;
-    }
-
-    if (!mainParsed) {
-      debugServer.warn('Could not process any main subtitle');
-      return { subtitles: [] };
-    }
-
-    // Process translations (1 version for speed - serverless optimization)
-    for (const transSubInfo of transSubList) {
-      if (finalSubtitles.length >= 1) break;
-      if (usedTransUrls.has(transSubInfo.url)) continue;
-      usedTransUrls.add(transSubInfo.url);
-
-      const version = finalSubtitles.length + 1;
-      debugServer.log(`Processing translation v${version}...`);
-
-      const transContent = await fetchSubtitleContent(transSubInfo.url, transSubInfo.lang);
-      if (!transContent) continue;
-
-      const transParsed = parseSrt(transContent);
-      if (!transParsed || transParsed.length === 0) continue;
-
-      const merged = mergeSubtitles([...mainParsed], transParsed, { mainLang, transLang });
-      if (!merged || merged.length === 0) continue;
-
-      const mergedSrt = formatSrt(merged);
-      if (!mergedSrt) continue;
-
-      // Store in cache (for local/backup)
-      const cacheKey = `${imdbId}_${season || ''}_${episode || ''}_${mainLang}_${transLang}_v${version}`;
-      storeSubtitle(cacheKey, mergedSrt);
-
-      // Use dynamic URL that regenerates subtitle on each request (for serverless)
-      const dynamicParams = [
-        type,
-        imdbId,
-        season || '0',
-        episode || '0',
-        mainLang,
-        transLang,
-        selectedMainSub.id,
-        transSubInfo.id
-      ].join('/');
-
-      finalSubtitles.push({
-        id: `dual-${selectedMainSub.id}-${transSubInfo.id}`,
-        url: `{{ADDON_URL}}/subs/${dynamicParams}.srt`,
-        lang: mainLang,
-        SubtitlesName: `Dual (${mainLang.toUpperCase()}+${transLang.toUpperCase()}) - ${getLanguageName(mainLang)} + ${getLanguageName(transLang)}`
-      });
-    }
-
-    debugServer.log(`Created ${finalSubtitles.length} merged subtitle(s)`);
+    debugServer.log(
+      `Created merged subtitle: matchRate=${(best.matchRate * 100).toFixed(1)}% ` +
+      `attempts=${best.attempts} passedGate=${best.passedGate}`
+    );
 
     return {
       subtitles: finalSubtitles,
@@ -742,60 +820,54 @@ async function generateDynamicSubtitle(type, imdbId, season, episode, mainLang, 
       return null;
     }
 
-    // Find the specific subtitle files by ID
-    const mainSubInfo = allSubtitles.find(s => String(s.id) === String(mainSubId));
-    const transSubInfo = allSubtitles.find(s => String(s.id) === String(transSubId));
+    // Build candidate pairs for this title; we'll start by trying the
+    // exact pair encoded in the URL (the one subtitlesHandler picked),
+    // then fall back to other candidates if the match rate is too low.
+    const candidatePairs = generateCandidatePairs(allSubtitles, mainLang, transLang);
 
-    if (!mainSubInfo || !transSubInfo) {
-      debugServer.warn('Specific subtitles not found, trying by language');
-      // Fallback: get best match by language
-      const mainSubList = filterSubtitlesByLanguage(allSubtitles, mainLang);
-      const transSubList = filterSubtitlesByLanguage(allSubtitles, transLang);
-      
-      if (!mainSubList || !transSubList) {
-        return null;
-      }
+    const requestedMain = allSubtitles.find(s => String(s.id) === String(mainSubId));
+    const requestedTrans = allSubtitles.find(s => String(s.id) === String(transSubId));
 
-      // Use first available
-      const mainContent = await fetchSubtitleContent(mainSubList[0].url, mainLang);
-      const transContent = await fetchSubtitleContent(transSubList[0].url, transLang);
-
-      if (!mainContent || !transContent) return null;
-
-      const mainParsed = parseSrt(mainContent);
-      const transParsed = parseSrt(transContent);
-
-      if (!mainParsed || !transParsed) return null;
-
-      const merged = mergeSubtitles(mainParsed, transParsed, { mainLang, transLang });
-      return formatSrt(merged);
+    let orderedPairs = candidatePairs;
+    if (requestedMain && requestedTrans) {
+      // Move the URL-requested pair to the front (or insert it if it
+      // wasn't in the candidate list, e.g. addon was upgraded mid-cache).
+      const isSameGroup =
+        requestedMain.g === requestedTrans.g && requestedMain.g != null;
+      const head = {
+        main: requestedMain,
+        trans: requestedTrans,
+        sameGroup: isSameGroup,
+        group: isSameGroup ? requestedMain.g : null,
+        source: 'requested'
+      };
+      orderedPairs = [
+        head,
+        ...candidatePairs.filter(
+          p => !(String(p.main.id) === String(mainSubId) &&
+                 String(p.trans.id) === String(transSubId))
+        )
+      ];
+    } else {
+      debugServer.warn(
+        'Requested specific pair not present in fresh subtitle list; ' +
+        'falling back to ranked candidates'
+      );
     }
 
-    // Fetch and parse both subtitle files
-    const mainContent = await fetchSubtitleContent(mainSubInfo.url, mainLang);
-    const transContent = await fetchSubtitleContent(transSubInfo.url, transLang);
+    if (orderedPairs.length === 0) return null;
 
-    if (!mainContent || !transContent) {
-      debugServer.warn('Could not fetch subtitle content');
+    const best = await selectAndMergeBestPair(orderedPairs, mainLang, transLang);
+    if (!best || !best.merged || best.merged.length === 0) {
+      debugServer.warn('No usable merged subtitle from any pair');
       return null;
     }
 
-    const mainParsed = parseSrt(mainContent);
-    const transParsed = parseSrt(transContent);
-
-    if (!mainParsed || !transParsed || mainParsed.length === 0 || transParsed.length === 0) {
-      debugServer.warn('Could not parse subtitles');
-      return null;
-    }
-
-    const merged = mergeSubtitles(mainParsed, transParsed, { mainLang, transLang });
-    if (!merged || merged.length === 0) {
-      debugServer.warn('Merge failed');
-      return null;
-    }
-
-    const srtContent = formatSrt(merged);
-    debugServer.log(`Generated ${merged.length} merged subtitle entries`);
+    const srtContent = best.mergedSrt;
+    debugServer.log(
+      `Generated ${best.merged.length} merged subtitle entries ` +
+      `(matchRate=${(best.matchRate * 100).toFixed(1)}%, attempts=${best.attempts})`
+    );
     
     return srtContent;
   } catch (error) {

--- a/lib/sourceSelection.js
+++ b/lib/sourceSelection.js
@@ -1,0 +1,207 @@
+/**
+ * Smart source-pair selection for the dual-subtitle merger.
+ *
+ * Background
+ * ----------
+ * The OpenSubtitles v3 stream API returns a flat list of subtitles per IMDB
+ * id, where each entry has only six fields:
+ *
+ *   { id, url, lang, SubEncoding, m, g }
+ *
+ * No fps, no filename, no download counts, no video size. The historical
+ * picker therefore just took the first hit per language and hoped for the
+ * best. On titles like The Sopranos S01E03 ENG+TUR that strategy paired
+ * subtitles from different releases, producing nonlinear local drift no
+ * sync engine can fully repair.
+ *
+ * Empirically the `g` field is a release/source grouping id: subtitles
+ * that share the same `g` come from the same source upload and are timed
+ * against the same video release. We measured the impact on Sopranos
+ * S01E03:
+ *   - cross-group pair (production today): 75.3% match rate
+ *   - same-`g` pair                       : 89.4% match rate
+ *
+ * This module exposes:
+ *   • rankCandidatesForLanguage  - rank the in-language candidates so the
+ *                                  top one is the best stand-alone choice.
+ *   • generateCandidatePairs     - produce ordered (main, trans) pairs to
+ *                                  try, preferring same-`g` and falling
+ *                                  back to ranked-by-language pairs. The
+ *                                  caller (subtitlesHandler) tries pairs
+ *                                  in order until one passes the
+ *                                  alignment quality gate.
+ */
+
+const { getLanguageAliases } = require('../encoding');
+
+/**
+ * Filter the flat sub list down to the ones whose lang code matches a given
+ * canonical language id (with all language aliases).
+ */
+function filterByLanguage(allSubtitles, languageId) {
+  if (!Array.isArray(allSubtitles) || !languageId) return [];
+  const aliases = getLanguageAliases(languageId);
+  return allSubtitles.filter(s => s && aliases.includes(s.lang));
+}
+
+/**
+ * Score a candidate subtitle on its own merits (not against a peer).
+ * Higher is better. Used only to break ties / order fallbacks; the
+ * cross-language `g` match still dominates pairing decisions.
+ */
+function selfScore(sub) {
+  if (!sub) return 0;
+  let s = 0;
+  // `m === 'i'` means "imdb match" in opensubtitles-v3 vocabulary; it's
+  // present on essentially every entry but we keep the bonus in case it
+  // ever differentiates.
+  if (sub.m === 'i') s += 10;
+  // Prefer commonly-used encodings; obscure ones tend to break decoders.
+  if (sub.SubEncoding === 'UTF-8') s += 5;
+  else if (sub.SubEncoding === 'CP1254' || sub.SubEncoding === 'CP1251') s += 2;
+  return s;
+}
+
+/**
+ * Rank candidates of a single language. Stable: ties keep original order
+ * (which the API delivers in download/popularity order).
+ */
+function rankCandidatesForLanguage(allSubtitles, languageId) {
+  const list = filterByLanguage(allSubtitles, languageId);
+  return list
+    .map((sub, idx) => ({ sub, idx }))
+    .sort((a, b) => {
+      const ds = selfScore(b.sub) - selfScore(a.sub);
+      if (ds !== 0) return ds;
+      return a.idx - b.idx;
+    })
+    .map(x => x.sub);
+}
+
+/**
+ * Build an ordered list of (main, trans) candidate pairs to try.
+ *
+ * `g` is a strong signal but it's not perfect — empirically (Sopranos
+ * S02E05) we sometimes find a same-`g` pair that syncs at ~73% while a
+ * cross-`g` pair from the API's own popularity order syncs at ~96%. So
+ * the strategy interleaves three sources to give the quality gate a
+ * diverse set within MAX_PAIR_ATTEMPTS attempts:
+ *
+ *   1. Best same-`g` pair (highest-ranked main whose `g` exists in trans).
+ *   2. Zipped popularity pair (mainList[0] × transList[0]) — what
+ *      production used to do. Cheap insurance for edge cases like S02E05.
+ *   3. Second-best same-`g` pair (different `g`, or same `g` with the
+ *      next best trans peer).
+ *   4. Remaining same-`g` and zipped pairs in order.
+ *
+ * @param {Array} allSubtitles
+ * @param {string} mainLang
+ * @param {string} transLang
+ * @param {object} [options]
+ * @param {number} [options.maxPairs=6]
+ * @param {number} [options.maxPerGroup=2]
+ * @returns {Array<{
+ *   main: object, trans: object, sameGroup: boolean,
+ *   group: (string|null), source: 'group'|'fallback'|'requested'
+ * }>}
+ */
+function generateCandidatePairs(allSubtitles, mainLang, transLang, options = {}) {
+  const { maxPairs = 6, maxPerGroup = 2 } = options;
+
+  const mainList = rankCandidatesForLanguage(allSubtitles, mainLang);
+  const transList = rankCandidatesForLanguage(allSubtitles, transLang);
+  if (mainList.length === 0 || transList.length === 0) return [];
+
+  const seen = new Set();
+  const pairKey = (m, t) => `${m.id}:${t.id}`;
+
+  // Build same-group pair queue (FIFO), highest-ranked main first.
+  const transByG = new Map();
+  for (const t of transList) {
+    const g = t.g;
+    if (g == null || g === '') continue;
+    if (!transByG.has(g)) transByG.set(g, []);
+    transByG.get(g).push(t);
+  }
+  const groupQueue = [];
+  for (const m of mainList) {
+    const peers = transByG.get(m.g);
+    if (!peers || peers.length === 0) continue;
+    let emittedForThisMain = 0;
+    for (const t of peers) {
+      const key = pairKey(m, t);
+      if (seen.has(key)) continue;
+      groupQueue.push({ main: m, trans: t, sameGroup: true, group: m.g, source: 'group' });
+      seen.add(key);
+      emittedForThisMain++;
+      if (emittedForThisMain >= maxPerGroup) break;
+    }
+  }
+
+  // Build zipped-popularity pair queue (the legacy behavior).
+  const zipQueue = [];
+  const zipLen = Math.min(mainList.length, transList.length);
+  for (let i = 0; i < zipLen; i++) {
+    const key = pairKey(mainList[i], transList[i]);
+    if (seen.has(key)) continue;
+    zipQueue.push({
+      main: mainList[i],
+      trans: transList[i],
+      sameGroup: mainList[i].g === transList[i].g && mainList[i].g != null,
+      group: mainList[i].g === transList[i].g ? mainList[i].g : null,
+      source: 'fallback'
+    });
+    seen.add(key);
+  }
+
+  // Interleave. Prefer the first same-`g` (typically a big win), then a
+  // zipped fallback (insurance for cases where `g` lies), then alternate.
+  const pairs = [];
+  const order = [groupQueue, zipQueue, groupQueue, zipQueue, groupQueue, zipQueue];
+  for (const queue of order) {
+    if (pairs.length >= maxPairs) break;
+    if (queue.length > 0) pairs.push(queue.shift());
+  }
+  // Drain remainders.
+  while (pairs.length < maxPairs && (groupQueue.length > 0 || zipQueue.length > 0)) {
+    if (groupQueue.length > 0) pairs.push(groupQueue.shift());
+    if (pairs.length >= maxPairs) break;
+    if (zipQueue.length > 0) pairs.push(zipQueue.shift());
+  }
+
+  // Last-resort cross-products: top main × each remaining trans, top trans
+  // × each remaining main. Useful when the languages have very few subs.
+  for (let i = 1; i < transList.length && pairs.length < maxPairs; i++) {
+    const key = pairKey(mainList[0], transList[i]);
+    if (seen.has(key)) continue;
+    pairs.push({
+      main: mainList[0],
+      trans: transList[i],
+      sameGroup: mainList[0].g === transList[i].g && mainList[0].g != null,
+      group: null,
+      source: 'fallback'
+    });
+    seen.add(key);
+  }
+  for (let i = 1; i < mainList.length && pairs.length < maxPairs; i++) {
+    const key = pairKey(mainList[i], transList[0]);
+    if (seen.has(key)) continue;
+    pairs.push({
+      main: mainList[i],
+      trans: transList[0],
+      sameGroup: mainList[i].g === transList[0].g && mainList[i].g != null,
+      group: null,
+      source: 'fallback'
+    });
+    seen.add(key);
+  }
+
+  return pairs;
+}
+
+module.exports = {
+  filterByLanguage,
+  rankCandidatesForLanguage,
+  generateCandidatePairs,
+  _internal: { selfScore }
+};

--- a/lib/syncEngine.js
+++ b/lib/syncEngine.js
@@ -1,0 +1,416 @@
+/**
+ * Subtitle alignment & matching engine.
+ *
+ * Solves the long-standing dual-subtitle desync problem in a principled way
+ * instead of relying on a single best-effort proximity threshold. The pipeline
+ * is staged so each stage only does what it can do confidently:
+ *
+ *   1. Global offset estimation (cross-correlation of "speaker active"
+ *      presence signals). Catches the most common failure mode: two subtitle
+ *      releases that are uniformly shifted by N seconds.
+ *
+ *   2. Linear drift correction (least-squares affine fit on anchor pairs).
+ *      Catches framerate-mismatch drift (e.g. 23.976 fps vs 25 fps) that
+ *      otherwise grows from 0 ms at the start to several seconds at the end.
+ *
+ *   3. Bipartite-style assignment with overlap-fraction scoring and used-set
+ *      tracking. Eliminates the "same translation cue glued to two different
+ *      primary cues" duplicate that the old greedy-by-start-time matcher
+ *      produced.
+ *
+ *   4. Optional 1:N consolidation. Lets a single primary cue absorb several
+ *      short translation cues that all overlap it (common when one language
+ *      splits a sentence into multiple cues).
+ *
+ * All public functions operate on millisecond-based subtitle records of the
+ * shape {startMs, endMs, ...}. The caller (addon.js#mergeSubtitles) converts
+ * to/from SRT timestamp strings around the call.
+ */
+
+/**
+ * Build a binary "speaker active" signal sampled at stepMs resolution.
+ * Cell i is 1 iff some cue is active during [i*stepMs, (i+1)*stepMs).
+ *
+ * @param {Array<{startMs:number,endMs:number}>} subs
+ * @param {number} cells
+ * @param {number} stepMs
+ * @returns {Uint8Array}
+ */
+function buildPresenceSignal(subs, cells, stepMs) {
+  const sig = new Uint8Array(cells);
+  for (const s of subs) {
+    if (!s || s.endMs <= s.startMs) continue;
+    const start = Math.max(0, Math.floor(s.startMs / stepMs));
+    const end = Math.min(cells - 1, Math.floor((s.endMs - 1) / stepMs));
+    for (let i = start; i <= end; i++) sig[i] = 1;
+  }
+  return sig;
+}
+
+function countActive(sig) {
+  let n = 0;
+  for (let i = 0; i < sig.length; i++) if (sig[i]) n++;
+  return n;
+}
+
+/**
+ * Estimate the global offset (ms) between two subtitle tracks via brute-force
+ * cross-correlation. Returns the offset to ADD to the secondary track's
+ * timestamps so it aligns to the primary.
+ *
+ * Returns 0 when the alignment is too ambiguous to trust (signals barely
+ * overlap, or no improvement over the lag=0 baseline).
+ *
+ * @param {Array} mainSubs
+ * @param {Array} transSubs
+ * @param {object} [options]
+ * @param {number} [options.maxOffsetMs=30000] - search window (±)
+ * @param {number} [options.stepMs=100]        - signal granularity
+ * @param {number} [options.minConfidence=0.25]
+ *        Best correlation score must be at least this fraction of the
+ *        theoretical maximum (min of two active counts) to be trusted.
+ * @returns {number} offset in ms (positive shifts trans later)
+ */
+function estimateOffsetMs(mainSubs, transSubs, options = {}) {
+  const {
+    maxOffsetMs = 30000,
+    stepMs = 100,
+    minConfidence = 0.25
+  } = options;
+
+  if (!mainSubs || !transSubs || mainSubs.length === 0 || transSubs.length === 0) {
+    return 0;
+  }
+
+  // Cross-correlation needs enough cues to be statistically meaningful;
+  // with only a handful of cues, the best lag is essentially noise and
+  // we may align two unrelated cues that happen to be alone in the file.
+  if (mainSubs.length < 5 || transSubs.length < 5) {
+    return 0;
+  }
+
+  const maxMain = mainSubs[mainSubs.length - 1].endMs || 0;
+  const maxTrans = transSubs[transSubs.length - 1].endMs || 0;
+  const totalDuration = Math.max(maxMain, maxTrans) + maxOffsetMs;
+  if (totalDuration <= 0) return 0;
+
+  const cells = Math.ceil(totalDuration / stepMs) + 1;
+  const main = buildPresenceSignal(mainSubs, cells, stepMs);
+  const trans = buildPresenceSignal(transSubs, cells, stepMs);
+
+  const mainActive = countActive(main);
+  const transActive = countActive(trans);
+  if (mainActive === 0 || transActive === 0) return 0;
+
+  const maxLag = Math.floor(maxOffsetMs / stepMs);
+  let bestLag = 0;
+  let bestScore = -1;
+  let zeroScore = 0;
+
+  for (let lag = -maxLag; lag <= maxLag; lag++) {
+    let score = 0;
+    const iStart = Math.max(0, -lag);
+    const iEnd = Math.min(cells, cells - lag);
+    for (let i = iStart; i < iEnd; i++) {
+      if (main[i] && trans[i + lag]) score++;
+    }
+    if (lag === 0) zeroScore = score;
+    if (score > bestScore) {
+      bestScore = score;
+      bestLag = lag;
+    }
+  }
+
+  // Confidence checks: best alignment must be meaningfully better than
+  // doing nothing, and must explain a reasonable share of the signal.
+  const maxPossible = Math.min(mainActive, transActive);
+  if (bestScore < minConfidence * maxPossible) return 0;
+  if (bestLag !== 0 && bestScore < zeroScore * 1.05) return 0;
+
+  // bestLag>0 means trans is delayed wrt main by bestLag*stepMs. To align trans
+  // to main we shift trans EARLIER, i.e. add a negative offset.
+  return -bestLag * stepMs;
+}
+
+/**
+ * Translate every cue's timestamps by a constant offset.
+ *
+ * @param {Array} subs
+ * @param {number} offsetMs
+ * @returns {Array} new array (input not mutated)
+ */
+function applyOffset(subs, offsetMs) {
+  if (!offsetMs) return subs;
+  return subs.map(s => ({
+    ...s,
+    startMs: s.startMs + offsetMs,
+    endMs: s.endMs + offsetMs
+  }));
+}
+
+/**
+ * Find anchor pairs (mainSub, transSub) where each main has a single clearly
+ * closest trans within the threshold. Used as the regression input for
+ * drift detection.
+ */
+function findAnchorPairs(mainSubs, transSubs, anchorThresholdMs) {
+  const anchors = [];
+  let j = 0;
+  for (const m of mainSubs) {
+    while (j < transSubs.length && transSubs[j].endMs < m.startMs - anchorThresholdMs) j++;
+    let bestK = -1;
+    let bestD = Infinity;
+    let secondD = Infinity;
+    for (let k = j; k < transSubs.length; k++) {
+      const t = transSubs[k];
+      if (t.startMs > m.endMs + anchorThresholdMs) break;
+      const d = Math.abs(t.startMs - m.startMs);
+      if (d < bestD) {
+        secondD = bestD;
+        bestD = d;
+        bestK = k;
+      } else if (d < secondD) {
+        secondD = d;
+      }
+    }
+    if (bestK >= 0 && bestD <= anchorThresholdMs && secondD > bestD * 1.5) {
+      anchors.push([m.startMs, transSubs[bestK].startMs]);
+    }
+  }
+  return anchors;
+}
+
+/**
+ * Estimate an affine timebase mapping y = a*x + b from main (x) to trans (y)
+ * using the anchor pairs. Returns null when there aren't enough confident
+ * anchors to fit a line meaningfully.
+ *
+ * @returns {{a:number,b:number,anchors:number}|null}
+ */
+function estimateAffineMapping(mainSubs, transSubs, options = {}) {
+  const {
+    anchorThresholdMs = 1500,
+    minAnchors = 8
+  } = options;
+
+  const anchors = findAnchorPairs(mainSubs, transSubs, anchorThresholdMs);
+  if (anchors.length < minAnchors) return null;
+
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (const [x, y] of anchors) {
+    sumX += x;
+    sumY += y;
+    sumXY += x * y;
+    sumXX += x * x;
+  }
+  const n = anchors.length;
+  const denom = n * sumXX - sumX * sumX;
+  if (denom === 0) return null;
+  const a = (n * sumXY - sumX * sumY) / denom;
+  const b = (sumY - a * sumX) / n;
+
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  // Clamp to a sane range; a far from 1 means anchors are noise.
+  if (a < 0.85 || a > 1.15) return null;
+
+  return { a, b, anchors: n };
+}
+
+/**
+ * Apply an affine timebase mapping (y = a*x + b describes trans wrt main).
+ * Maps trans times INTO main's timebase: main_t = (trans_t - b) / a.
+ */
+function applyAffine(subs, mapping) {
+  const { a, b } = mapping;
+  return subs.map(s => ({
+    ...s,
+    startMs: Math.round((s.startMs - b) / a),
+    endMs: Math.round((s.endMs - b) / a)
+  }));
+}
+
+/**
+ * Jaccard-style overlap score: intersection / union of the two intervals.
+ * Returns 0 if the cues do not overlap at all.
+ */
+function overlapScore(m, t) {
+  const overlapStart = Math.max(m.startMs, t.startMs);
+  const overlapEnd = Math.min(m.endMs, t.endMs);
+  const overlap = overlapEnd - overlapStart;
+  if (overlap <= 0) return 0;
+  const unionStart = Math.min(m.startMs, t.startMs);
+  const unionEnd = Math.max(m.endMs, t.endMs);
+  const union = unionEnd - unionStart;
+  if (union <= 0) return 0;
+  return overlap / union;
+}
+
+/**
+ * Greedy bipartite assignment of trans cues to main cues using overlap
+ * scoring. Each trans cue can be claimed by at most one main cue, which
+ * eliminates the duplicate-translation bug.
+ *
+ * If allowMultiTrans is true, a main cue may absorb multiple trans cues
+ * that all materially overlap it (common when one language splits one
+ * sentence into several short cues).
+ *
+ * @returns {Map<number, number[]>} mainIdx -> sorted transIdx[]
+ */
+function assignMatches(mainSubs, transSubs, options = {}) {
+  const {
+    threshold = 1500,
+    minOverlapFraction = 0.05,
+    allowMultiTrans = true,
+    maxTransPerMain = 3
+  } = options;
+
+  const usedTrans = new Set();
+  const matches = new Map();
+
+  let transStart = 0;
+  for (let mi = 0; mi < mainSubs.length; mi++) {
+    const m = mainSubs[mi];
+    while (
+      transStart < transSubs.length &&
+      transSubs[transStart].endMs < m.startMs - threshold
+    ) {
+      transStart++;
+    }
+
+    const candidates = [];
+    for (let ti = transStart; ti < transSubs.length; ti++) {
+      const t = transSubs[ti];
+      if (t.startMs > m.endMs + threshold) break;
+      if (usedTrans.has(ti)) continue;
+
+      const score = overlapScore(m, t);
+      if (score > 0) {
+        candidates.push({ ti, score });
+        continue;
+      }
+      // Fall-back: cues that don't strictly overlap but start very close
+      // by, score by inverse-distance. Helps when both files use slightly
+      // different cue boundaries but the dialogue line is the same.
+      const startDiff = Math.abs(t.startMs - m.startMs);
+      if (startDiff < threshold) {
+        candidates.push({ ti, score: 0.001 + (1 / (1 + startDiff)) });
+      }
+    }
+
+    if (candidates.length === 0) continue;
+    candidates.sort((a, b) => b.score - a.score);
+
+    if (!allowMultiTrans) {
+      const best = candidates[0];
+      usedTrans.add(best.ti);
+      matches.set(mi, [best.ti]);
+      continue;
+    }
+
+    const picked = [];
+    for (const c of candidates) {
+      if (picked.length >= maxTransPerMain) break;
+      // Always take the top match. Take additional matches only if their
+      // overlap is meaningful — otherwise we'd be jamming unrelated lines.
+      if (picked.length === 0 || c.score >= minOverlapFraction) {
+        picked.push(c.ti);
+        usedTrans.add(c.ti);
+      } else {
+        break;
+      }
+    }
+    if (picked.length > 0) {
+      picked.sort((a, b) => a - b);
+      matches.set(mi, picked);
+    }
+  }
+
+  return matches;
+}
+
+/**
+ * Top-level alignment + matching pipeline.
+ *
+ * @param {Array} mainSubs   array of {startMs,endMs,...}
+ * @param {Array} transSubs  array of {startMs,endMs,...}
+ * @param {object} [options]
+ * @returns {{
+ *   matches: Map<number, number[]>,
+ *   transAdjusted: Array,
+ *   offsetMs: number,
+ *   drift: ({a:number,b:number,anchors:number}|null),
+ *   matchRate: number
+ * }}
+ */
+function alignAndMatch(mainSubs, transSubs, options = {}) {
+  const {
+    enableOffset = true,
+    enableDrift = true,
+    matchThreshold = 1500,
+    allowMultiTrans = true,
+    log = () => {}
+  } = options;
+
+  let trans = transSubs;
+  let offsetMs = 0;
+  let drift = null;
+
+  if (enableOffset && trans.length > 0 && mainSubs.length > 0) {
+    offsetMs = estimateOffsetMs(mainSubs, trans);
+    if (offsetMs !== 0) {
+      trans = applyOffset(trans, offsetMs);
+      log(`syncEngine: applied global offset ${offsetMs}ms`);
+    }
+  }
+
+  if (enableDrift && trans.length >= 8 && mainSubs.length >= 8) {
+    drift = estimateAffineMapping(mainSubs, trans);
+    // Only act on drift large enough to matter (>0.1% slope deviation).
+    if (drift && Math.abs(drift.a - 1) > 0.001) {
+      trans = applyAffine(trans, drift);
+      log(
+        `syncEngine: applied affine drift a=${drift.a.toFixed(5)} ` +
+        `b=${drift.b.toFixed(0)} from ${drift.anchors} anchors`
+      );
+    } else {
+      drift = null;
+    }
+  }
+
+  const matches = assignMatches(mainSubs, trans, {
+    threshold: matchThreshold,
+    allowMultiTrans
+  });
+
+  const matchRate = mainSubs.length > 0 ? matches.size / mainSubs.length : 0;
+  log(
+    `syncEngine: matched ${matches.size}/${mainSubs.length} ` +
+    `(${(matchRate * 100).toFixed(1)}%)`
+  );
+
+  return {
+    matches,
+    transAdjusted: trans,
+    offsetMs,
+    drift,
+    matchRate
+  };
+}
+
+module.exports = {
+  estimateOffsetMs,
+  applyOffset,
+  estimateAffineMapping,
+  applyAffine,
+  assignMatches,
+  alignAndMatch,
+  overlapScore,
+  _internal: {
+    buildPresenceSignal,
+    findAnchorPairs,
+    countActive
+  }
+};

--- a/lib/syncEngine.js
+++ b/lib/syncEngine.js
@@ -233,6 +233,91 @@ function applyAffine(subs, mapping) {
 }
 
 /**
+ * Estimate per-window local offsets for non-linear drift (e.g. ad breaks
+ * cut from one release but not the other, or a re-edit between releases).
+ * Splits the timeline into overlapping windows, runs cross-correlation in
+ * each, and returns a sorted list of {centerMs, offsetMs} anchors.
+ *
+ * Windows with too few cues, or where cross-correlation fails the
+ * confidence check, are dropped. This means the caller must interpolate
+ * gracefully when a query time falls outside the anchor list.
+ */
+function estimateLocalOffsets(mainSubs, transSubs, options = {}) {
+  const {
+    windowMs = 300000,        // 5 min
+    stepMs = 150000,          // 2.5 min stride => 50% overlap
+    minCuesPerWindow = 5,
+    maxLocalOffsetMs = 15000
+  } = options;
+
+  if (!mainSubs || !transSubs || mainSubs.length === 0 || transSubs.length === 0) {
+    return [];
+  }
+
+  const total = Math.max(
+    mainSubs[mainSubs.length - 1].endMs || 0,
+    transSubs[transSubs.length - 1].endMs || 0
+  );
+  if (total <= 0) return [];
+
+  const anchors = [];
+  for (let winStart = 0; winStart < total; winStart += stepMs) {
+    const winEnd = winStart + windowMs;
+    const mainSlice = mainSubs.filter(s => s.startMs >= winStart && s.startMs < winEnd);
+    const transSlice = transSubs.filter(
+      s => s.startMs >= winStart - maxLocalOffsetMs &&
+           s.startMs < winEnd + maxLocalOffsetMs
+    );
+    if (mainSlice.length < minCuesPerWindow || transSlice.length < minCuesPerWindow) {
+      continue;
+    }
+
+    const localOffset = estimateOffsetMs(mainSlice, transSlice, {
+      maxOffsetMs: maxLocalOffsetMs,
+      stepMs: 100,
+      minConfidence: 0.3
+    });
+
+    // estimateOffsetMs returns 0 when the alignment is ambiguous; treat
+    // that as "no anchor here" rather than as a real zero, since a zero
+    // anchor surrounded by non-zero ones would confuse interpolation.
+    if (localOffset === 0) continue;
+    anchors.push({ centerMs: winStart + windowMs / 2, offsetMs: localOffset });
+  }
+  return anchors;
+}
+
+/**
+ * Apply per-window local offsets via piecewise-linear interpolation.
+ * For each cue, pick the offset of the nearest anchor (interpolated when
+ * between two anchors). Cues outside the anchor range use the nearest end
+ * anchor's offset (extrapolation by repetition).
+ */
+function applyLocalOffsets(subs, anchors) {
+  if (!anchors || anchors.length === 0) return subs;
+  const sorted = [...anchors].sort((a, b) => a.centerMs - b.centerMs);
+
+  function offsetAt(t) {
+    if (t <= sorted[0].centerMs) return sorted[0].offsetMs;
+    if (t >= sorted[sorted.length - 1].centerMs) return sorted[sorted.length - 1].offsetMs;
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const a = sorted[i];
+      const b = sorted[i + 1];
+      if (t >= a.centerMs && t <= b.centerMs) {
+        const ratio = (t - a.centerMs) / (b.centerMs - a.centerMs);
+        return Math.round(a.offsetMs + ratio * (b.offsetMs - a.offsetMs));
+      }
+    }
+    return 0;
+  }
+
+  return subs.map(s => {
+    const o = offsetAt(s.startMs);
+    return { ...s, startMs: s.startMs + o, endMs: s.endMs + o };
+  });
+}
+
+/**
  * Jaccard-style overlap score: intersection / union of the two intervals.
  * Returns 0 if the cues do not overlap at all.
  */
@@ -371,6 +456,7 @@ function alignAndMatch(mainSubs, transSubs, options = {}) {
   const {
     enableOffset = true,
     enableDrift = true,
+    enableLocalOffsets = true,
     matchThreshold = 1500,
     allowMultiTrans = true,
     log = () => {}
@@ -379,6 +465,7 @@ function alignAndMatch(mainSubs, transSubs, options = {}) {
   let trans = transSubs;
   let offsetMs = 0;
   let drift = null;
+  let localAnchors = [];
 
   if (enableOffset && trans.length > 0 && mainSubs.length > 0) {
     offsetMs = estimateOffsetMs(mainSubs, trans);
@@ -402,6 +489,32 @@ function alignAndMatch(mainSubs, transSubs, options = {}) {
     }
   }
 
+  if (enableLocalOffsets && trans.length >= 20 && mainSubs.length >= 20) {
+    localAnchors = estimateLocalOffsets(mainSubs, trans);
+    if (localAnchors.length >= 2) {
+      const range = localAnchors.reduce(
+        (acc, a) => ({
+          min: Math.min(acc.min, a.offsetMs),
+          max: Math.max(acc.max, a.offsetMs)
+        }),
+        { min: Infinity, max: -Infinity }
+      );
+      // Only worth applying when the local offsets actually disagree
+      // with each other; otherwise the global offset already handled it.
+      if (range.max - range.min >= 500) {
+        trans = applyLocalOffsets(trans, localAnchors);
+        log(
+          `syncEngine: applied ${localAnchors.length} local offset anchors ` +
+          `(spread ${range.min}..${range.max} ms)`
+        );
+      } else {
+        localAnchors = [];
+      }
+    } else {
+      localAnchors = [];
+    }
+  }
+
   const matches = assignMatches(mainSubs, trans, {
     threshold: matchThreshold,
     allowMultiTrans
@@ -418,6 +531,7 @@ function alignAndMatch(mainSubs, transSubs, options = {}) {
     transAdjusted: trans,
     offsetMs,
     drift,
+    localAnchors,
     matchRate
   };
 }
@@ -427,6 +541,8 @@ module.exports = {
   applyOffset,
   estimateAffineMapping,
   applyAffine,
+  estimateLocalOffsets,
+  applyLocalOffsets,
   assignMatches,
   alignAndMatch,
   overlapScore,

--- a/lib/syncEngine.js
+++ b/lib/syncEngine.js
@@ -249,27 +249,54 @@ function overlapScore(m, t) {
 }
 
 /**
- * Greedy bipartite assignment of trans cues to main cues using overlap
- * scoring. Each trans cue can be claimed by at most one main cue, which
- * eliminates the duplicate-translation bug.
+ * Score one (main, trans) pair. Returns 0 when they're irrelevant.
  *
- * If allowMultiTrans is true, a main cue may absorb multiple trans cues
- * that all materially overlap it (common when one language splits one
- * sentence into several short cues).
+ * Primary signal is interval overlap (Jaccard). When the cues do not
+ * overlap at all but start within `threshold` ms of each other we still
+ * give a small inverse-distance score so that cue-boundary mismatches
+ * don't drop a translation entirely.
+ */
+function pairScore(m, t, threshold) {
+  const o = overlapScore(m, t);
+  if (o > 0) return o;
+  const startDiff = Math.abs(t.startMs - m.startMs);
+  if (startDiff < threshold) return 0.001 + 1 / (1 + startDiff);
+  return 0;
+}
+
+/**
+ * Bipartite assignment of trans cues to main cues using a two-pass
+ * strategy that maximizes overall match rate while still preventing
+ * the "same trans cue glued to two different mains" bug.
+ *
+ *   Pass 1 — global score sort: enumerate every (main, trans) pair
+ *            within `threshold`, sort by score desc, then walk the list
+ *            assigning each pair only if neither side is already used.
+ *            This is a Hungarian-lite that produces the best 1:1
+ *            assignment in practice without the algorithmic overhead.
+ *
+ *   Pass 2 — 1:N consolidation (only when allowMultiTrans): for each
+ *            main that already got a match in pass 1, look for ADJACENT
+ *            unused trans cues that materially overlap and absorb them.
+ *            Handles the case where one language splits a single line
+ *            into several short cues.
  *
  * @returns {Map<number, number[]>} mainIdx -> sorted transIdx[]
  */
 function assignMatches(mainSubs, transSubs, options = {}) {
   const {
     threshold = 1500,
-    minOverlapFraction = 0.05,
+    minOverlapFraction = 0.1,
     allowMultiTrans = true,
     maxTransPerMain = 3
   } = options;
 
-  const usedTrans = new Set();
   const matches = new Map();
+  const usedMain = new Set();
+  const usedTrans = new Set();
 
+  // ---- Pass 1: global score-sorted 1:1 assignment ------------------------
+  const pairs = [];
   let transStart = 0;
   for (let mi = 0; mi < mainSubs.length; mi++) {
     const m = mainSubs[mi];
@@ -279,53 +306,48 @@ function assignMatches(mainSubs, transSubs, options = {}) {
     ) {
       transStart++;
     }
-
-    const candidates = [];
     for (let ti = transStart; ti < transSubs.length; ti++) {
       const t = transSubs[ti];
       if (t.startMs > m.endMs + threshold) break;
-      if (usedTrans.has(ti)) continue;
+      const score = pairScore(m, t, threshold);
+      if (score > 0) pairs.push({ mi, ti, score });
+    }
+  }
 
-      const score = overlapScore(m, t);
-      if (score > 0) {
-        candidates.push({ ti, score });
-        continue;
+  pairs.sort((a, b) => b.score - a.score);
+  for (const p of pairs) {
+    if (usedMain.has(p.mi) || usedTrans.has(p.ti)) continue;
+    usedMain.add(p.mi);
+    usedTrans.add(p.ti);
+    matches.set(p.mi, [p.ti]);
+  }
+
+  if (!allowMultiTrans) return matches;
+
+  // ---- Pass 2: extend each main with adjacent unused trans cues ----------
+  for (const [mi, picked] of matches) {
+    if (picked.length >= maxTransPerMain) continue;
+    const m = mainSubs[mi];
+    const anchor = picked[0];
+
+    // Look at neighbors to the right and left of the anchor trans cue.
+    for (const dir of [1, -1]) {
+      let ti = anchor + dir;
+      while (
+        ti >= 0 &&
+        ti < transSubs.length &&
+        picked.length < maxTransPerMain &&
+        !usedTrans.has(ti)
+      ) {
+        const t = transSubs[ti];
+        const score = overlapScore(m, t);
+        if (score < minOverlapFraction) break;
+        picked.push(ti);
+        usedTrans.add(ti);
+        ti += dir;
       }
-      // Fall-back: cues that don't strictly overlap but start very close
-      // by, score by inverse-distance. Helps when both files use slightly
-      // different cue boundaries but the dialogue line is the same.
-      const startDiff = Math.abs(t.startMs - m.startMs);
-      if (startDiff < threshold) {
-        candidates.push({ ti, score: 0.001 + (1 / (1 + startDiff)) });
-      }
     }
-
-    if (candidates.length === 0) continue;
-    candidates.sort((a, b) => b.score - a.score);
-
-    if (!allowMultiTrans) {
-      const best = candidates[0];
-      usedTrans.add(best.ti);
-      matches.set(mi, [best.ti]);
-      continue;
-    }
-
-    const picked = [];
-    for (const c of candidates) {
-      if (picked.length >= maxTransPerMain) break;
-      // Always take the top match. Take additional matches only if their
-      // overlap is meaningful — otherwise we'd be jamming unrelated lines.
-      if (picked.length === 0 || c.score >= minOverlapFraction) {
-        picked.push(c.ti);
-        usedTrans.add(c.ti);
-      } else {
-        break;
-      }
-    }
-    if (picked.length > 0) {
-      picked.sort((a, b) => a - b);
-      matches.set(mi, picked);
-    }
+    picked.sort((a, b) => a - b);
   }
 
   return matches;

--- a/test.js
+++ b/test.js
@@ -409,6 +409,216 @@ test('Parse then format roundtrip preserves content', () => {
 });
 
 // ============================================================================
+// syncEngine — alignment + matching pipeline
+// ============================================================================
+console.log('\n--- syncEngine ---');
+
+const {
+  estimateOffsetMs,
+  applyOffset,
+  estimateAffineMapping,
+  applyAffine,
+  assignMatches,
+  alignAndMatch,
+  overlapScore
+} = require('./lib/syncEngine');
+
+function makeTimedCues(specs) {
+  return specs.map(([startMs, endMs, text], i) => ({
+    id: String(i + 1),
+    startMs,
+    endMs,
+    text
+  }));
+}
+
+test('overlapScore: full overlap = 1', () => {
+  const m = { startMs: 1000, endMs: 4000 };
+  const t = { startMs: 1000, endMs: 4000 };
+  assert.strictEqual(overlapScore(m, t), 1);
+});
+
+test('overlapScore: no overlap = 0', () => {
+  const m = { startMs: 1000, endMs: 2000 };
+  const t = { startMs: 3000, endMs: 4000 };
+  assert.strictEqual(overlapScore(m, t), 0);
+});
+
+test('overlapScore: partial overlap is between 0 and 1', () => {
+  const m = { startMs: 1000, endMs: 3000 };
+  const t = { startMs: 2000, endMs: 4000 };
+  const s = overlapScore(m, t);
+  assert.ok(s > 0 && s < 1);
+});
+
+test('estimateOffsetMs: detects +2000ms offset on trans track', () => {
+  const main = makeTimedCues([
+    [1000, 3000, 'a'], [4000, 6000, 'b'], [7000, 9000, 'c'],
+    [10000, 12000, 'd'], [13000, 15000, 'e'], [16000, 18000, 'f']
+  ]);
+  const trans = makeTimedCues([
+    [3000, 5000, 'A'], [6000, 8000, 'B'], [9000, 11000, 'C'],
+    [12000, 14000, 'D'], [15000, 17000, 'E'], [18000, 20000, 'F']
+  ]);
+  const offset = estimateOffsetMs(main, trans);
+  // trans is delayed by 2s so offset should be -2000 (shift trans earlier)
+  assert.ok(Math.abs(offset - -2000) <= 100, `expected ~-2000, got ${offset}`);
+});
+
+test('estimateOffsetMs: returns 0 when tracks already aligned', () => {
+  const main = makeTimedCues([
+    [1000, 3000, 'a'], [4000, 6000, 'b'], [7000, 9000, 'c'],
+    [10000, 12000, 'd'], [13000, 15000, 'e']
+  ]);
+  const trans = makeTimedCues([
+    [1000, 3000, 'A'], [4000, 6000, 'B'], [7000, 9000, 'C'],
+    [10000, 12000, 'D'], [13000, 15000, 'E']
+  ]);
+  const offset = estimateOffsetMs(main, trans);
+  assert.ok(Math.abs(offset) <= 200, `aligned tracks should yield ~0 offset, got ${offset}`);
+});
+
+test('estimateOffsetMs: returns 0 with empty inputs', () => {
+  assert.strictEqual(estimateOffsetMs([], []), 0);
+  assert.strictEqual(estimateOffsetMs(null, null), 0);
+});
+
+test('applyOffset: shifts every cue by offset', () => {
+  const subs = makeTimedCues([[1000, 2000, 'a'], [3000, 4000, 'b']]);
+  const out = applyOffset(subs, 500);
+  assert.strictEqual(out[0].startMs, 1500);
+  assert.strictEqual(out[1].endMs, 4500);
+  // Original is not mutated
+  assert.strictEqual(subs[0].startMs, 1000);
+});
+
+test('estimateAffineMapping: detects framerate-style linear drift', () => {
+  // Main timestamps; trans is "stretched" by factor 1.01 (drift growing
+  // over time) — simulates a small framerate mismatch. We keep the
+  // factor small so simple nearest-neighbor anchor pairing stays correct
+  // across the whole file; in real use the offset stage runs before this
+  // and leaves only the residual drift here.
+  const main = [];
+  const trans = [];
+  for (let i = 0; i < 20; i++) {
+    const t = i * 5000 + 1000;
+    main.push({ id: String(i + 1), startMs: t, endMs: t + 2000, text: `m${i}` });
+    const tt = Math.round(t * 1.01 + 200);
+    trans.push({ id: String(i + 1), startMs: tt, endMs: tt + 2000, text: `t${i}` });
+  }
+  const mapping = estimateAffineMapping(main, trans, { anchorThresholdMs: 5000 });
+  assert.ok(mapping, 'expected an affine mapping');
+  assert.ok(Math.abs(mapping.a - 1.01) < 0.005, `slope a=${mapping.a}`);
+  assert.ok(mapping.anchors >= 8);
+});
+
+test('estimateAffineMapping: returns null when too few anchors', () => {
+  const main = makeTimedCues([[1000, 2000, 'a'], [5000, 6000, 'b']]);
+  const trans = makeTimedCues([[1000, 2000, 'A'], [5000, 6000, 'B']]);
+  const mapping = estimateAffineMapping(main, trans);
+  assert.strictEqual(mapping, null);
+});
+
+test('assignMatches: never assigns same trans cue twice', () => {
+  // Two main cues that are both close to a single trans cue
+  const main = makeTimedCues([[1000, 2000, 'a'], [2200, 3200, 'b']]);
+  const trans = makeTimedCues([[1100, 2100, 'shared']]);
+  const matches = assignMatches(main, trans, { threshold: 1500 });
+  const assigned = [];
+  for (const arr of matches.values()) for (const t of arr) assigned.push(t);
+  const seen = new Set(assigned);
+  assert.strictEqual(seen.size, assigned.length, 'no trans cue may appear twice');
+});
+
+test('assignMatches: 1:N — main cue absorbs multiple short trans cues', () => {
+  const main = makeTimedCues([[1000, 5000, 'long']]);
+  const trans = makeTimedCues([
+    [1000, 2000, 'first half'],
+    [3000, 4500, 'second half']
+  ]);
+  const matches = assignMatches(main, trans, { threshold: 1500, allowMultiTrans: true });
+  const idxs = matches.get(0);
+  assert.ok(idxs && idxs.length === 2, 'expected both trans cues to be merged into the long main');
+});
+
+test('mergeSubtitles: fixes Sopranos-style off-by-one shift', () => {
+  // Re-creates the bug seen on Sopranos S01E03: trans cues are shifted by ~2.5s
+  // so the old greedy nearest-start-time matcher glued each trans cue to the
+  // PRECEDING main cue. The new pipeline detects the global offset and lines
+  // them back up.
+  const main = [
+    { id: '1', startTime: '00:01:50,243', endTime: '00:01:52,612', text: 'We found this truck on the side of the road.' },
+    { id: '2', startTime: '00:01:52,612', endTime: '00:01:57,117', text: 'There might be some transmission trouble.' },
+    { id: '3', startTime: '00:01:57,250', endTime: '00:01:59,252', text: "What's goin' on here? That's the truck." },
+    { id: '4', startTime: '00:01:59,752', endTime: '00:02:02,755', text: 'The one stolen in newark?' },
+    { id: '5', startTime: '00:02:04,257', endTime: '00:02:07,260', text: "It's a gift from tony soprano." },
+    { id: '6', startTime: '00:02:10,763', endTime: '00:02:13,766', text: "Let's call the cops." },
+    { id: '7', startTime: '00:02:14,017', endTime: '00:02:17,520', text: "I don't fuckin' believe it." },
+    { id: '8', startTime: '00:02:17,520', endTime: '00:02:19,522', text: 'Listen, you fuck.' }
+  ];
+  // Translation track shifted later by 2.5s
+  const trans = [
+    { id: '1', startTime: '00:01:52,743', endTime: '00:01:55,112', text: 'Bu kamyonu yolun kenarinda bulduk.' },
+    { id: '2', startTime: '00:01:55,112', endTime: '00:01:59,617', text: 'Viteste sorun olabilir.' },
+    { id: '3', startTime: '00:01:59,750', endTime: '00:02:01,752', text: "Burada neler oluyor? O bizim kamyonumuz." },
+    { id: '4', startTime: '00:02:02,252', endTime: '00:02:05,255', text: 'Newarkta calinan mi?' },
+    { id: '5', startTime: '00:02:06,757', endTime: '00:02:09,760', text: 'Tony Sopranonun hediyesi.' },
+    { id: '6', startTime: '00:02:13,263', endTime: '00:02:16,266', text: 'Polisi arayalim.' },
+    { id: '7', startTime: '00:02:16,517', endTime: '00:02:20,020', text: 'Inanamiyorum.' },
+    { id: '8', startTime: '00:02:20,020', endTime: '00:02:22,022', text: 'Dinle gerizekali.' }
+  ];
+
+  const merged = mergeSubtitles(main, trans, { mainLang: 'eng', transLang: 'tur' });
+
+  function transFor(text) {
+    const row = merged.find(m => m.text.includes(text));
+    return row ? row.text : null;
+  }
+  assert.ok(transFor('We found this truck').includes('Bu kamyonu yolun kenarinda bulduk.'));
+  assert.ok(transFor('transmission trouble').includes('Viteste sorun olabilir.'));
+  assert.ok(transFor('stolen in newark').includes('Newarkta calinan mi'));
+  assert.ok(transFor('gift from tony soprano').includes('Tony Sopranonun hediyesi.'));
+  assert.ok(transFor("Let's call the cops").includes('Polisi arayalim.'));
+
+  // No translation should appear under more than one main line.
+  const transTexts = [
+    'Bu kamyonu yolun kenarinda bulduk.',
+    'Viteste sorun olabilir.',
+    'Newarkta calinan mi',
+    'Tony Sopranonun hediyesi.',
+    'Polisi arayalim.'
+  ];
+  for (const t of transTexts) {
+    const occurrences = merged.filter(m => m.text.includes(t)).length;
+    assert.strictEqual(occurrences, 1, `"${t}" should appear in exactly one merged cue, got ${occurrences}`);
+  }
+});
+
+test('mergeSubtitles: never duplicates a trans cue across mains', () => {
+  // Two adjacent main cues, only one trans cue around them — old algorithm
+  // would assign that trans cue to BOTH mains. The new one assigns once.
+  const main = [
+    { id: '1', startTime: '00:00:01,000', endTime: '00:00:02,000', text: 'one' },
+    { id: '2', startTime: '00:00:02,200', endTime: '00:00:03,200', text: 'two' }
+  ];
+  const trans = [
+    { id: '1', startTime: '00:00:01,100', endTime: '00:00:02,100', text: 'tek-trans' }
+  ];
+  const merged = mergeSubtitles(main, trans, { mainLang: 'eng', transLang: 'tur' });
+  const occurrences = merged.filter(m => m.text.includes('tek-trans')).length;
+  assert.strictEqual(occurrences, 1);
+});
+
+test('mergeSubtitles: emits all main cues even when trans is empty', () => {
+  const main = [
+    { id: '1', startTime: '00:00:01,000', endTime: '00:00:02,000', text: 'alone' }
+  ];
+  const merged = mergeSubtitles(main, [], { mainLang: 'eng', transLang: 'tur' });
+  assert.strictEqual(merged.length, 1);
+  assert.ok(merged[0].text.includes('<b>alone</b>'));
+});
+
+// ============================================================================
 // RESULTS
 // ============================================================================
 console.log('\n========================================');

--- a/test.js
+++ b/test.js
@@ -619,6 +619,203 @@ test('mergeSubtitles: emits all main cues even when trans is empty', () => {
 });
 
 // ============================================================================
+// sourceSelection — pair generation
+// ============================================================================
+console.log('\n--- sourceSelection ---');
+
+const {
+  filterByLanguage,
+  rankCandidatesForLanguage,
+  generateCandidatePairs
+} = require('./lib/sourceSelection');
+
+test('filterByLanguage: filters by exact lang code', () => {
+  // OpenSubtitles v3 always uses 3-letter ISO codes here, so we don't
+  // need fuzzy alias matching across 2/3-letter codes — but we still
+  // honor whatever getLanguageAliases produces.
+  const subs = [
+    { id: '1', lang: 'eng', g: '1' },
+    { id: '2', lang: 'tur', g: '1' },
+    { id: '3', lang: 'eng', g: '2' }
+  ];
+  const eng = filterByLanguage(subs, 'eng');
+  assert.strictEqual(eng.length, 2);
+  assert.deepStrictEqual(eng.map(s => s.id).sort(), ['1', '3']);
+});
+
+test('rankCandidatesForLanguage: stable order, prefers UTF-8', () => {
+  const subs = [
+    { id: 'a', lang: 'eng', g: '1', SubEncoding: 'CP1254', m: 'i' },
+    { id: 'b', lang: 'eng', g: '1', SubEncoding: 'UTF-8', m: 'i' },
+    { id: 'c', lang: 'eng', g: '2', SubEncoding: 'ASCII', m: 'i' }
+  ];
+  const ranked = rankCandidatesForLanguage(subs, 'eng');
+  assert.strictEqual(ranked[0].id, 'b', 'UTF-8 should outrank others');
+});
+
+test('generateCandidatePairs: prefers same-`g` over zipped fallback (Sopranos pattern)', () => {
+  // Mirrors the real Sopranos S01E03 response: ENG only has g=7, TUR has
+  // g=1 (first by API ranking) and g=7 (second). Old picker grabbed
+  // ENG[0]+TUR[0] = different releases. New picker must produce the
+  // same-`g` pair as the head of the list.
+  const subs = [
+    { id: 'eng-7-A', lang: 'eng', g: '7' },
+    { id: 'tur-1',   lang: 'tur', g: '1' },
+    { id: 'tur-7',   lang: 'tur', g: '7' }
+  ];
+  const pairs = generateCandidatePairs(subs, 'eng', 'tur');
+  assert.ok(pairs.length >= 1);
+  assert.strictEqual(pairs[0].main.id, 'eng-7-A');
+  assert.strictEqual(pairs[0].trans.id, 'tur-7');
+  assert.strictEqual(pairs[0].sameGroup, true);
+  assert.strictEqual(pairs[0].source, 'group');
+});
+
+test('generateCandidatePairs: falls back to zipped order when no `g` overlap', () => {
+  const subs = [
+    { id: 'eng-1', lang: 'eng', g: '1' },
+    { id: 'tur-2', lang: 'tur', g: '2' }
+  ];
+  const pairs = generateCandidatePairs(subs, 'eng', 'tur');
+  assert.ok(pairs.length >= 1);
+  assert.strictEqual(pairs[0].main.id, 'eng-1');
+  assert.strictEqual(pairs[0].trans.id, 'tur-2');
+  assert.strictEqual(pairs[0].sameGroup, false);
+  assert.strictEqual(pairs[0].source, 'fallback');
+});
+
+test('generateCandidatePairs: respects maxPairs cap and returns at most that many', () => {
+  const subs = [];
+  for (let i = 0; i < 6; i++) subs.push({ id: `e${i}`, lang: 'eng', g: String(i) });
+  for (let i = 0; i < 6; i++) subs.push({ id: `t${i}`, lang: 'tur', g: String(i) });
+  const pairs = generateCandidatePairs(subs, 'eng', 'tur', { maxPairs: 3 });
+  assert.strictEqual(pairs.length, 3);
+});
+
+test('generateCandidatePairs: emits no pairs when one language is missing', () => {
+  const subs = [{ id: 'eng-1', lang: 'eng', g: '1' }];
+  const pairs = generateCandidatePairs(subs, 'eng', 'tur');
+  assert.strictEqual(pairs.length, 0);
+});
+
+test('generateCandidatePairs: top ranked main with same-`g` peer wins over higher-ranked main without one', () => {
+  // ENG[0] is best ranked but has no TUR peer at g=99. ENG[1] has a TUR
+  // peer at g=7. We want the same-group pair to lead.
+  const subs = [
+    { id: 'eng-99', lang: 'eng', g: '99' },
+    { id: 'eng-7',  lang: 'eng', g: '7'  },
+    { id: 'tur-7',  lang: 'tur', g: '7'  }
+  ];
+  const pairs = generateCandidatePairs(subs, 'eng', 'tur');
+  assert.strictEqual(pairs[0].main.id, 'eng-7');
+  assert.strictEqual(pairs[0].trans.id, 'tur-7');
+  assert.strictEqual(pairs[0].sameGroup, true);
+});
+
+// ============================================================================
+// syncEngine — sliding-window local offsets
+// ============================================================================
+console.log('\n--- syncEngine.estimateLocalOffsets ---');
+
+const {
+  estimateLocalOffsets,
+  applyLocalOffsets
+} = require('./lib/syncEngine');
+
+// Build a non-periodic dialogue pattern so cross-correlation can't lock
+// onto a self-similarity peak. We use an LCG-based pseudo-random spacing,
+// reproducible across runs without depending on Math.random.
+function buildDialogueTrack(count, startMs = 1000, seed = 42) {
+  let s = seed;
+  const rng = () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; };
+  const cues = [];
+  let t = startMs;
+  for (let i = 0; i < count; i++) {
+    const dur = 1500 + Math.floor(rng() * 2500);   // 1.5–4.0s cues
+    const gap = 500 + Math.floor(rng() * 6000);    // 0.5–6.5s gaps
+    cues.push({ id: String(i + 1), startMs: t, endMs: t + dur, text: `c${i}` });
+    t += dur + gap;
+  }
+  return cues;
+}
+
+test('estimateLocalOffsets: detects piecewise drift across windows', () => {
+  // First half: trans is +1500ms; second half: trans is -2500ms. We turn
+  // off the global offset stage by feeding a dataset where each segment
+  // averages to its own local offset; the test is just that the sliding
+  // window finds segment-specific anchors.
+  const main = buildDialogueTrack(60);
+  const split = main.length / 2;
+  const trans = main.map((c, i) => {
+    const o = i < split ? 1500 : -2500;
+    return { ...c, startMs: c.startMs + o, endMs: c.endMs + o };
+  });
+  const anchors = estimateLocalOffsets(main, trans, {
+    windowMs: 60000, stepMs: 30000, minCuesPerWindow: 4, maxLocalOffsetMs: 5000
+  });
+  assert.ok(anchors.length >= 3, `expected several anchors, got ${anchors.length}`);
+  // We don't pin exact offsets (cross-correlation has step granularity),
+  // but we expect early anchors to lean positive (trans is delayed) and
+  // late anchors to lean negative (trans is early). estimateOffsetMs
+  // returns the shift applied TO trans, so positive = shift later.
+  const half = main[main.length - 1].startMs / 2;
+  const early = anchors.filter(a => a.centerMs < half);
+  const late = anchors.filter(a => a.centerMs > half);
+  assert.ok(early.length > 0 && late.length > 0);
+  const earlyMean = early.reduce((s, a) => s + a.offsetMs, 0) / early.length;
+  const lateMean = late.reduce((s, a) => s + a.offsetMs, 0) / late.length;
+  assert.ok(
+    earlyMean < lateMean,
+    `early anchors should differ from late ones; got early=${earlyMean} late=${lateMean}`
+  );
+});
+
+test('estimateLocalOffsets: returns empty list with too-short tracks', () => {
+  const anchors = estimateLocalOffsets([], []);
+  assert.deepStrictEqual(anchors, []);
+});
+
+test('applyLocalOffsets: piecewise-linear interpolation between anchors', () => {
+  const subs = [
+    { startMs: 0,     endMs: 1000 },
+    { startMs: 60000, endMs: 61000 },
+    { startMs: 120000,endMs: 121000 }
+  ];
+  const anchors = [
+    { centerMs: 0,      offsetMs: 0 },
+    { centerMs: 120000, offsetMs: 1000 }
+  ];
+  const out = applyLocalOffsets(subs, anchors);
+  assert.strictEqual(out[0].startMs, 0,       'first anchor end held');
+  assert.strictEqual(out[1].startMs, 60500,   'midpoint interpolated');
+  assert.strictEqual(out[2].startMs, 121000,  'second anchor end held');
+});
+
+test('alignAndMatch: piecewise-drifted track matches better with local offsets enabled', () => {
+  // Build a non-periodic dialogue pattern with two segments that have
+  // different local offsets. Local-offsets-on must beat local-offsets-off
+  // when global offset is disabled (so we measure only the local stage).
+  const main = buildDialogueTrack(80);
+  const split = main.length / 2;
+  const trans = main.map((c, i) => {
+    const o = i < split ? 1500 : -2500;
+    return { ...c, startMs: c.startMs + o, endMs: c.endMs + o };
+  });
+  const withLocal = alignAndMatch(main, trans, {
+    matchThreshold: 1500, enableLocalOffsets: true,
+    enableOffset: false, enableDrift: false
+  });
+  const withoutLocal = alignAndMatch(main, trans, {
+    matchThreshold: 1500, enableLocalOffsets: false,
+    enableOffset: false, enableDrift: false
+  });
+  assert.ok(
+    withLocal.matchRate > withoutLocal.matchRate + 0.1,
+    `expected local-offset path to outperform by >10pp; got ${withLocal.matchRate.toFixed(3)} vs ${withoutLocal.matchRate.toFixed(3)}`
+  );
+});
+
+// ============================================================================
 // RESULTS
 // ============================================================================
 console.log('\n========================================');


### PR DESCRIPTION
## Özet

Dual altyazı senkronizasyon kalitesini OpenSubtitles tek-kaynak içinde sistematik olarak iyileştirir. Sopranos S01E03'te %76.9 → %99.5 (+22.7pp), 165 dil-kombinasyon ölçümünde ortalama **+11.15pp** kazanç, **0 anlamlı regresyon**.

## İki ana parça

### 1. Multi-stage alignment engine — `lib/syncEngine.js`

Tek geçişli "en yakın başlangıç zamanı" eşleştirmesini, beş aşamalı bir hatlatla değiştirir:

1. **Global offset** — cue varlık sinyallerinin cross-correlation'ı ile uniform shift tespiti (Sopranos'ta ~2.5s'lik kaymayı çözer).
2. **Linear drift** — anchor pair'larda least-squares affine fit; framerate uyumsuzluğunu (23.976 vs 25 fps) düzeltir.
3. **Sliding-window local offsets** — pencere bazlı cross-correlation; release cut'ları, ad break farkları gibi non-linear drift için segment-segment düzeltme.
4. **Bipartite assignment** — used-set takibi ile Jaccard overlap skoru; bir çeviri cue'sunun iki ana cue'ya iliştirilmesini önler.
5. **1:N consolidation** — uzun bir ana cue'nun birden fazla kısa çeviri cue'sunu yutması (cue sınır uyumsuzluklarını çözer).

### 2. Smart source pairing — `lib/sourceSelection.js`

OpenSubtitles v3 stream API'sinin döndürdüğü `g` field'ı (release/source grouping ID) önceden göz ardı ediliyordu. Bu yüzden farklı release'lerin altyazıları eşleştiriliyor, hiçbir hizalama motoru bunu tam çözemiyordu.

- Same-`g` pair'lar (aynı release) öncelikli emit edilir.
- Legacy zipped-popularity pair (eski production seçimi) ikinci sırada — `g`'nin yanıltıcı olduğu durumlar için sigorta.
- `subtitlesHandler` ve `generateDynamicSubtitle` 3 pair'a kadar match-rate quality gate (≥%85) ile dener; kazanan pair seçilir.

`mergeSubtitles` artık `matchRate` ve `alignment` non-enumerable property'leri ile zenginleştirilmiş, geriye uyumlu kalır.

## Ölçümler

165 dil-kombinasyon × 11 başlık (Sopranos, Inception, Shawshank, The Dark Knight, Pulp Fiction, The Matrix, GoT, Breaking Bad, Stranger Things, The Office) gerçek production verisi karşılaştırması:

| | Sayı |
|---|---|
| WIN (>0.5pp iyileşme) | **86** |
| TIE (±0.5pp içinde) | **77** |
| LOSS (>0.5pp gerileme) | **2** (her ikisi de <3pp, %95+ skorlu durumlar) |
| Mean Δ | **+11.15pp** |

**Birincil dile göre:**
- ENG primary (n=123): mean **+12.40pp**
- SPA primary (n=19): mean **+10.08pp**
- GER primary (n=7): mean **+9.37pp**
- FRE primary (n=16): mean **+3.52pp**

**Dramatik düzelmeler:**
- The Dark Knight (eng+ger): %0.6 → **%92.8** (+92.2pp; production tamamen yanlış release seçiyormuş)
- Shawshank (eng+pob): %53.0 → **%100.0** (+47.0pp)
- The Dark Knight (eng+por): %47.8 → **%99.3** (+51.6pp)
- The Office (eng+dan): %45.4 → **%100.0** (+54.6pp)
- Inception (eng+nld): %65.8 → **%99.6** (+33.9pp)
- Sopranos S01E03 (eng+tur): %76.9 → **%99.5** (+22.7pp) — orijinal raporlanan bug

## Test planı

- [x] Yeni unit testler (sourceSelection + sliding-window offset + alignAndMatch karşılaştırma): 80/80 yeşil
- [x] 165 dil-kombinasyon canlı production veri karşılaştırması: +11.15pp mean, 0 anlamlı regresyon
- [x] E2E smoke test (subtitlesHandler → generateDynamicSubtitle → SRT içerik): Sopranos S01E03 644 cue'nun 641'i çevirili (%99.5)
- [ ] Manuel Stremio testi: en az bir TV başlığı + bir film, ENG+TUR yapılandırma
- [ ] Manuel Stremio testi: Sopranos S01E03 (orijinal bug)

## Notlar

- Master canlıya henüz push'lanmamıştı; merge sonrası tüm bu değişiklikler tek seferde Vercel'e deploy olur.
- Quality gate cold-path başına maksimum 3 fetch + parse yapar; ortalamada 1-2 (çoğu başlıkta ilk pair ≥%85).
- `parsedCache` aynı pair denemesinde fetch'leri tekrarlamaz, latency üzerinde marjinal etki.