### PR TITLE
Robust SRT parsing + forward video matching params

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -13,49 +13,87 @@ const { debugServer, sanitizeForLogging } = require('./lib/debug');
 /**
  * Simple SRT parser (more reliable than external libraries)
  */
+function parseTimestampLine(line) {
+  if (!line || typeof line !== 'string') return null;
+  if (!line.includes('-->')) return null;
+
+  const timePattern = '(\\d{1,2}:\\d{2}:\\d{2}[,.]\\d{1,3})';
+  const match = line.match(new RegExp(`^\\s*${timePattern}\\s*-->\\s*${timePattern}`));
+  if (!match) return null;
+
+  const startMs = parseTimeToMs(match[1]);
+  const endMs = parseTimeToMs(match[2]);
+
+  return {
+    startTime: msToSrtTime(startMs),
+    endTime: msToSrtTime(endMs)
+  };
+}
+
 function parseSrtSimple(srtText) {
   const lines = srtText.trim().split('\n');
   const subtitles = [];
   let current = null;
-  
+  let pendingId = null;
+
+  function pushCurrent() {
+    if (
+      current &&
+      current.startTime &&
+      current.endTime &&
+      typeof current.text === 'string' &&
+      current.text.trim()
+    ) {
+      subtitles.push(current);
+    }
+    current = null;
+  }
+
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i].trim();
-    
-    // Skip empty lines
+    const timing = parseTimestampLine(line);
+
+    // Empty line => cue boundary
     if (!line) {
-      if (current && current.text) {
-        subtitles.push(current);
-        current = null;
-      }
+      pushCurrent();
+      pendingId = null;
       continue;
     }
-    
-    // Check if it's a sequence number
-    if (!current && /^\d+$/.test(line)) {
-      current = { id: line, text: '' };
+
+    // Timestamp line starts a new cue
+    if (timing) {
+      pushCurrent();
+      current = {
+        id: pendingId || String(subtitles.length + 1),
+        startTime: timing.startTime,
+        endTime: timing.endTime,
+        text: ''
+      };
+      pendingId = null;
       continue;
     }
-    
-    // Check if it's a timestamp line
-    if (current && !current.startTime && line.includes('-->')) {
-      const [start, end] = line.split('-->').map(s => s.trim());
-      current.startTime = start;
-      current.endTime = end;
+
+    // Cue IDs are optional in the wild. If the *next* line is a
+    // timestamp, treat the current line as the cue id (even if it's not
+    // numeric, e.g. VTT named IDs).
+    const nextLine = i + 1 < lines.length ? lines[i + 1].trim() : '';
+    if (parseTimestampLine(nextLine)) {
+      if (current) pushCurrent();
+      pendingId = line;
       continue;
     }
-    
+
+    // Ignore preamble/garbage until a cue is started.
+    if (!current) continue;
+
     // Otherwise it's text
-    if (current && current.startTime) {
-      if (current.text) current.text += '\n';
-      current.text += line;
-    }
+    if (current.text) current.text += '\n';
+    current.text += line;
   }
-  
+
   // Add last subtitle if exists
-  if (current && current.text) {
-    subtitles.push(current);
-  }
-  
+  pushCurrent();
+
   return subtitles;
 }
 
@@ -86,6 +124,36 @@ const {
 } = require('./languages');
 const { alignAndMatch } = require('./lib/syncEngine');
 const { generateCandidatePairs } = require('./lib/sourceSelection');
+
+// Optional video-matching parameters (forwarded from Stremio extras).
+// These help OpenSubtitles pick the right release variant for the exact
+// video file the user is playing.
+const VIDEO_PARAM_KEYS = ['filename', 'videoSize', 'videoHash'];
+
+function normalizeVideoParams(params = {}) {
+  const normalized = {};
+  if (!params || typeof params !== 'object') return normalized;
+
+  for (const key of VIDEO_PARAM_KEYS) {
+    let value = params[key];
+    if (Array.isArray(value)) value = value[0];
+    if (value == null) continue;
+
+    const s = String(value).trim();
+    if (!s) continue;
+    normalized[key] = s;
+  }
+  return normalized;
+}
+
+function serializeVideoParams(params = {}) {
+  const normalized = normalizeVideoParams(params);
+  const search = new URLSearchParams();
+  for (const key of VIDEO_PARAM_KEYS) {
+    if (normalized[key]) search.set(key, normalized[key]);
+  }
+  return search.toString();
+}
 
 // Match rate at or above this is considered "good enough" — we stop
 // trying further candidate pairs. Empirically high-quality matches land
@@ -170,9 +238,12 @@ async function fetchAllSubtitles(imdbId, type, season = null, episode = null, vi
 
   // Add query params for better matching
   const queryParams = [];
-  if (videoParams.filename) queryParams.push(`filename=${encodeURIComponent(videoParams.filename)}`);
-  if (videoParams.videoSize) queryParams.push(`videoSize=${videoParams.videoSize}`);
-  if (videoParams.videoHash) queryParams.push(`videoHash=${videoParams.videoHash}`);
+  const normalizedVideoParams = normalizeVideoParams(videoParams);
+  if (normalizedVideoParams.filename) {
+    queryParams.push(`filename=${encodeURIComponent(normalizedVideoParams.filename)}`);
+  }
+  if (normalizedVideoParams.videoSize) queryParams.push(`videoSize=${normalizedVideoParams.videoSize}`);
+  if (normalizedVideoParams.videoHash) queryParams.push(`videoHash=${normalizedVideoParams.videoHash}`);
   
   if (queryParams.length > 0) {
     apiUrl += `/${queryParams.join('&')}`;
@@ -720,6 +791,7 @@ async function subtitlesHandler({ type, id, extra, config }) {
       videoSize: extra?.videoSize,
       videoHash: extra?.videoHash
     };
+    const videoQuery = serializeVideoParams(videoParams);
 
     // Fetch all subtitles
     debugServer.log('Fetching subtitles from OpenSubtitles...');
@@ -767,7 +839,7 @@ async function subtitlesHandler({ type, id, extra, config }) {
 
     const finalSubtitles = [{
       id: `dual-${best.main.id}-${best.trans.id}`,
-      url: `{{ADDON_URL}}/subs/${dynamicParams}.srt`,
+      url: `{{ADDON_URL}}/subs/${dynamicParams}.srt${videoQuery ? `?${videoQuery}` : ''}`,
       lang: mainLang,
       SubtitlesName:
         `Dual (${mainLang.toUpperCase()}+${transLang.toUpperCase()}) - ` +
@@ -800,10 +872,24 @@ builder.defineSubtitlesHandler(subtitlesHandler);
  * entirely — even ahead of Vercel's edge cache (which ALSO caches via
  * Cache-Control headers in server.js routes).
  */
-async function generateDynamicSubtitle(type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId) {
+async function generateDynamicSubtitle(
+  type,
+  imdbId,
+  season,
+  episode,
+  mainLang,
+  transLang,
+  mainSubId,
+  transSubId,
+  videoParams = {}
+) {
   debugServer.log('Dynamic subtitle generation:', { type, imdbId, mainLang, transLang });
 
-  const cacheKey = `${imdbId}_${season || ''}_${episode || ''}_${mainLang}_${transLang}_${mainSubId}_${transSubId}`;
+  const videoCacheFragment = serializeVideoParams(videoParams);
+  const cacheKey =
+    `${imdbId}_${season || ''}_${episode || ''}` +
+    `_${mainLang}_${transLang}_${mainSubId}_${transSubId}` +
+    `_${videoCacheFragment || ''}`;
   const cached = getSubtitle(cacheKey);
   if (cached) {
     debugServer.log(`Cache hit (in-instance): ${cacheKey}`);
@@ -812,11 +898,13 @@ async function generateDynamicSubtitle(type, imdbId, season, episode, mainLang, 
 
   try {
     // Fetch all subtitles
+    const normalizedVideoParams = normalizeVideoParams(videoParams);
     const allSubtitles = await fetchAllSubtitles(
       imdbId, 
       type, 
       season !== '0' ? season : null, 
-      episode !== '0' ? episode : null
+      episode !== '0' ? episode : null,
+      normalizedVideoParams
     );
 
     if (!allSubtitles) {

--- a/lib/syncEngine.js
+++ b/lib/syncEngine.js
@@ -102,6 +102,12 @@ function estimateOffsetMs(mainSubs, transSubs, options = {}) {
   const transActive = countActive(trans);
   if (mainActive === 0 || transActive === 0) return 0;
 
+  // Pre-collect active indices for main
+  const mainActiveIdxs = [];
+  for (let i = 0; i < cells; i++) {
+    if (main[i]) mainActiveIdxs.push(i);
+  }
+
   const maxLag = Math.floor(maxOffsetMs / stepMs);
   let bestLag = 0;
   let bestScore = -1;
@@ -109,10 +115,22 @@ function estimateOffsetMs(mainSubs, transSubs, options = {}) {
 
   for (let lag = -maxLag; lag <= maxLag; lag++) {
     let score = 0;
-    const iStart = Math.max(0, -lag);
-    const iEnd = Math.min(cells, cells - lag);
-    for (let i = iStart; i < iEnd; i++) {
-      if (main[i] && trans[i + lag]) score++;
+    if (lag >= 0) {
+      for (let k = 0; k < mainActiveIdxs.length; k++) {
+        const i = mainActiveIdxs[k];
+        const j = i + lag;
+        if (j < cells && trans[j]) {
+          score++;
+        }
+      }
+    } else {
+      for (let k = 0; k < mainActiveIdxs.length; k++) {
+        const i = mainActiveIdxs[k];
+        const j = i + lag;
+        if (j >= 0 && trans[j]) {
+          score++;
+        }
+      }
     }
     if (lag === 0) zeroScore = score;
     if (score > bestScore) {

--- a/server.js
+++ b/server.js
@@ -282,12 +282,21 @@ app.get('/subtitles/:filename', (req, res) => {
 // URL format: /subs/:type/:imdbId/:season/:episode/:mainLang/:transLang/:mainSubId/:transSubId.srt
 app.get('/subs/:type/:imdbId/:season/:episode/:mainLang/:transLang/:mainSubId/:transSubId.srt', async (req, res) => {
   const { type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId } = req.params;
+
+  // Optional video matching params (forwarded as query-string by the
+  // subtitles handler). These help OpenSubtitles pick the right
+  // release variant for the specific video.
+  const videoParams = {
+    filename: req.query && req.query.filename ? req.query.filename : undefined,
+    videoSize: req.query && req.query.videoSize ? req.query.videoSize : undefined,
+    videoHash: req.query && req.query.videoHash ? req.query.videoHash : undefined
+  };
   
   debugServer.log(`Dynamic subtitle request: ${type}/${imdbId} ${mainLang}+${transLang}`);
   
   try {
     const content = await generateDynamicSubtitle(
-      type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId
+      type, imdbId, season, episode, mainLang, transLang, mainSubId, transSubId, videoParams
     );
     
     if (!content) {
@@ -398,29 +407,24 @@ app.get('/:config/subtitles/:type/:id/:extra?.json', async (req, res) => {
 // Parse extra parameters from URL
 function parseExtra(extraStr) {
   const extra = {};
-  
-  // Handle the format: videoHash.videoSize.filename or just extra params
-  const parts = extraStr.split('.');
-  
-  // Try to parse as key=value pairs
-  for (const part of parts) {
-    if (part.includes('=')) {
-      const [key, value] = part.split('=');
-      extra[key] = value;
-    }
+  if (!extraStr) return extra;
+
+  // Stremio passes addon extras as a path segment (not a real query
+  // string). Older formats use dots as separators. The tricky bit is
+  // filenames themselves contain dots, so we must only replace dots
+  // that appear *before a known key= sequence*.
+  const normalized = extraStr.replace(
+    /\.(?=(?:videoHash|videoSize|filename|imdbId|season|episode)=)/g,
+    '&'
+  );
+
+  // Now we can safely parse via URLSearchParams (handles URL encoding
+  // and dotted filenames).
+  const params = new URLSearchParams(normalized);
+  for (const [key, value] of params.entries()) {
+    if (key && value != null) extra[key] = value;
   }
-  
-  // Also handle query-style params
-  if (extraStr.includes('&')) {
-    const params = extraStr.split('&');
-    for (const param of params) {
-      if (param.includes('=')) {
-        const [key, value] = param.split('=');
-        extra[key] = decodeURIComponent(value);
-      }
-    }
-  }
-  
+
   return extra;
 }
 


### PR DESCRIPTION
This PR cherry-picks improvements from fork commit c19efebd... focusing on reliability/compatibility:

- Harden `parseSrtSimple` to handle cues without numeric cue IDs and SRTs with missing blank separators.
- Improve `parseExtra` to correctly parse dotted filenames and dotted key separators.
- Forward `filename`, `videoSize`, `videoHash` as query params on the `/subs/...srt` URL and include them in dynamic subtitle caching and OpenSubtitles filtering.

Unit tests: `npm test` => 80 passed.